### PR TITLE
Family graph v2

### DIFF
--- a/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
+++ b/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
@@ -36,23 +36,8 @@ namespace KL
                 Rect = rect;
                 Relation = relationType;
             }
-            // public override bool Equals(object obj)
-            // {
-            //     if (obj is Node other)
-            //     {
-            //         return Rect.Equals(other.Rect) && Relation == other.Relation;
-            //     }
-            //     return false;
-            // }
-            // public override int GetHashCode()
-            // {
-            //     int hashCode = 17;
-            //     hashCode = hashCode * 31 + Rect.GetHashCode();
-            //     hashCode = hashCode * 31 + Relation.GetHashCode();
-            //     return hashCode;
-            // }
         }
-        struct Link
+        class Link
         {
             public Node Node;
             public int Index;
@@ -63,6 +48,7 @@ namespace KL
                 Index = index;
                 Anchor = anchorPoint;
             }
+            public void ChangeIndex(int index) => Index = index;
 
         }
         SerializedObject serializedObject;
@@ -99,9 +85,8 @@ namespace KL
 
             // Calculate the center of the groupRect
             Vector2 windowCenter = new(position.width / 2, position.height / 2);
-            Rect rootNodeRect = new(windowCenter.x + nodeSize.x,
+            Rect rootNodeRect = new(windowCenter.x - nodeSize.x / 2,
                                     (windowCenter.y / 2) + nodeSize.y / 2, nodeSize.x, 110);
-            // nodes.Add(rootNodeRect, RelationType.Root);
             nodes.Add(new Node(rootNodeRect, RelationType.Root));
         }
 
@@ -115,6 +100,7 @@ namespace KL
             window.position = new Rect(windowPosition.x, windowPosition.y, windowSize.x * 3, windowSize.y);
             window.Show();
         }
+        #region  OnGUI
         void OnGUI()
         {
             /* -------------------------------------------------------------------------- */
@@ -199,6 +185,8 @@ namespace KL
                 }
             }
         }
+        #endregion
+
         #region Nodes
         Node NewNode(float x, float y, RelationType type)
         {
@@ -214,9 +202,9 @@ namespace KL
                 return;
             }
             Node oldNode = nodes[nodeIndex];
-            Rect newRect = new Rect(x, y, oldNode.Rect.width, oldNode.Rect.height);
-            Node newNode = new Node(newRect, oldNode.Relation);
-            nodes[nodeIndex] = new Node(newRect, oldNode.Relation);
+            Rect newRect = new(x, y, oldNode.Rect.width, oldNode.Rect.height);
+            Node newNode = new(newRect, oldNode.Relation);
+            nodes[nodeIndex] = new(newRect, oldNode.Relation);
 
             // Transfer the polityMembers reference if it exists
             if (nodeIndex < polityMembers.Count && polityMembers[nodeIndex] != null)
@@ -229,20 +217,19 @@ namespace KL
             polityMembers.RemoveAt(nodes.IndexOf(node));
             nodes.Remove(node);
         }
+        #endregion
+
         #region Parent
-        int GetParentNodeCount()
-        {
-            int count = 0;
-            foreach (var node in nodes)
-                if (node.Relation == RelationType.Parent)
-                    count++;
-            return count;
-        }
+
         void AddParentNode()
         {
-            int parentCount = GetParentNodeCount();
-            if (polityMembers[0].family.parents.Count < 2 &&
-                parentCount < 2)
+            int parentCount = 0;
+            foreach (var node in nodes)
+                if (node.Relation == RelationType.Parent)
+                    parentCount++;
+            Debug.LogError("parent node count " + parentCount);
+            // if (polityMembers[0].family.parents.Count < 2 &&
+            //     parentCount < 2)
             {
                 switch (parentCount)
                 {
@@ -288,6 +275,7 @@ namespace KL
             CreateLink(childNode, parentNode, CurveAnchor.Top);
         }
         #endregion
+        #region  DrawNode
         void DrawNode(int id)
         {
             while (polityMembers.Count <= id) polityMembers.Add(null);
@@ -325,19 +313,55 @@ namespace KL
                 // if (polityMembers[id] != null && PrefabUtility.IsPartOfPrefabAsset(polityMembers[id]))
                 {
                     // if (!CheckForDuplicateNode(id))
+                    EditorGUILayout.BeginHorizontal();
                     {
-                        EditorGUILayout.BeginHorizontal();
+                        if (nodes[id].Relation == RelationType.Partner)
                         {
-                            if (nodes[id].Relation == RelationType.Partner)
-                            {
-                                if (GUILayout.Button("Add Child", GUILayout.ExpandWidth(true)))
-                                    AddChildrenNode(nodes[id]);
-                            }
-                            if (GUILayout.Button("Remove", GUILayout.ExpandWidth(true)))
-                                DeleteLink(id);
+                            if (GUILayout.Button("Add Child", GUILayout.ExpandWidth(true)))
+                                AddChildrenNode(nodes[id]);
                         }
-                        EditorGUILayout.EndHorizontal();
+                        if (GUILayout.Button("Remove", GUILayout.ExpandWidth(true)))
+                        {
+                            DeleteLink(id);
+                            bool moveParent = false;
+                            foreach (var node in nodes)
+                                switch (node.Relation)
+                                {
+                                    case RelationType.Parent:
+                                        foreach (var pair in links)
+                                            if (pair.Key.Node.Equals(node))
+                                            {
+                                                Debug.LogError("Removed parent node " + id + " node ID " + nodes.IndexOf(node));
+                                                Debug.Log("Pair matched index " + pair.Key.Index);
+                                                if (pair.Key.Index > id)
+                                                {
+                                                    pair.Key.ChangeIndex(id);
+                                                    moveParent = true;
+                                                }
+                                                Debug.Log("Pair matched index after " + pair.Key.Index);
+                                            }
+                                        break;
+                                    case RelationType.Partner:
+                                        foreach (var pair in links)
+                                            if (pair.Key.Node.Equals(node))
+                                            {
+                                                Debug.LogError("Removed partner node " + id + " node ID " + nodes.IndexOf(node));
+                                                Debug.Log("Pair matched index " + pair.Key.Index);
+                                                if (pair.Key.Index > id)
+                                                {
+                                                    pair.Key.ChangeIndex(id);
+                                                    // moveParent = true;
+                                                }
+                                                Debug.Log("Pair matched index after " + pair.Key.Index);
+                                            }
+                                        break;
+                                }
+                            if (moveParent)
+                                MoveNode(nodes[id], nodes[0].Rect.x, nodes[0].Rect.y - nodeSize.y * 2f);
+                            // }
+                        }
                     }
+                    EditorGUILayout.EndHorizontal();
                 }
             }
             // GUI.DragWindow();
@@ -353,12 +377,7 @@ namespace KL
             links.Add(new(startNode, startIndex, anchor), new(endNode, endIndex, endAnchor));
             Debug.Log("start Index " + startIndex + " end Index " + endIndex);
 
-            foreach (var pair in links)
-            {
-                // DrawNodeCurve(pair.Key.Node.Rect, pair.Value.Node.Rect, pair.Key.Anchor, pair.Value.Anchor);
-                Debug.Log("link node " + pair.Key.Node.Rect.position + " to " + pair.Value.Node.Rect.position
-                 + " index " + pair.Key.Index + " to " + pair.Value.Index);
-            }
+
         }
 
         void MoveLink(int nodeIndex, Node newNode)
@@ -367,7 +386,7 @@ namespace KL
             foreach (var pair in links)
                 if (pair.Key.Index == nodeIndex)
                     keysToUpdate.Add(pair.Key);
-
+            Debug.Log("Keys to update " + keysToUpdate.Count);
             foreach (var key in keysToUpdate)
             {
                 Link value = links[key];
@@ -375,6 +394,7 @@ namespace KL
                 links.Add(new Link(newNode, key.Index, key.Anchor), value);
             }
         }
+
         void LinkFamily(int id)
         {
             PolityMember member = polityMembers[id];
@@ -398,26 +418,6 @@ namespace KL
                 switch (nodes[id].Relation)
                 {
                     case RelationType.Parent:
-                        bool partnerFound = false;
-                        // for (int i = 0; i < member.family.partners.Count; i++)
-                        // {
-                        //     if (member.family.partners[i].partner == valueMember)
-                        //     {
-                        //         if (!member.family.partners[i].children.Contains(valueMember))
-                        //             member.family.partners[i].children.Add(valueMember);
-                        //         partnerFound = true;
-                        //         break;
-                        //     }
-                        // }
-
-                        // if (!partnerFound)
-                        // {
-                        //     PolityFamily.FamilyStruct.PartnerStruct newPartner = new()
-                        //     {
-                        //         children = new List<PolityMember> { valueMember }
-                        //     };
-                        //     member.family.partners.Add(newPartner);
-                        // }
 
                         if (!valueMember.family.parents.Contains(member))
                             valueMember.family.parents.Add(member);
@@ -430,8 +430,8 @@ namespace KL
         }
         void DeleteLink(int id, bool deleteFamily = true)
         {
-            Link linkToRemoveKey = new();
-            Link linkToRemoveValue = new();
+            Link linkToRemoveKey = null;
+            Link linkToRemoveValue = null;
             foreach (var pair in links)
                 if (pair.Key.Index == id)
                 {
@@ -463,7 +463,9 @@ namespace KL
             // if (keysToRemove.Count > 0)
             // Debug.Log("Removed " + keysToRemove.Count + " connections with ID " + id);
         }
+        #endregion
 
+        #region Init
         /* -------------------------------------------------------------------------- */
         /*                             NODE INITIALIZATION                            */
         /* -------------------------------------------------------------------------- */
@@ -491,8 +493,8 @@ namespace KL
                 // if (i != 0) currentXOffset += nodeSize.x * 2f;
                 // Node parentNode = NewNode(rootRect.x + currentXOffset, rootRect.y - nodeSize.y * 2f, RelationType.Parent);
                 // CreateLink(parentNode, nodes[0], CurveAnchor.Bottom);
-                AddParentNode();
                 polityMembers.Add(root.family.parents[i]);
+                AddParentNode();
             }
             // currentXOffset = nodeSize.x * 2f;
             #endregion
@@ -533,7 +535,6 @@ namespace KL
             // }
             isRootGenerated = true;
         }
-
         #endregion
 
         bool CheckForDuplicateNode(int id)

--- a/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
+++ b/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
@@ -23,7 +23,6 @@ namespace KL
             Partner,
             Children,
         }
-        RelationType relationType;
         List<PolityMember> polityMembers = new();
 
         /* ----------------------------- NODE RENDERERS ----------------------------- */
@@ -37,6 +36,21 @@ namespace KL
                 Rect = rect;
                 Relation = relationType;
             }
+            // public override bool Equals(object obj)
+            // {
+            //     if (obj is Node other)
+            //     {
+            //         return Rect.Equals(other.Rect) && Relation == other.Relation;
+            //     }
+            //     return false;
+            // }
+            // public override int GetHashCode()
+            // {
+            //     int hashCode = 17;
+            //     hashCode = hashCode * 31 + Rect.GetHashCode();
+            //     hashCode = hashCode * 31 + Relation.GetHashCode();
+            //     return hashCode;
+            // }
         }
         struct Link
         {
@@ -245,16 +259,15 @@ namespace KL
             }
         }
         #endregion
-        //         float xPos = nodes[0].Rect.x + nodeSize.x * (2 + partnerNodes.Count);
-        // float yPos = nodes[0].Rect.position.y;
+
         #region Partner
         void AddPartnerNode()
         {
-            List<Node> partnerNodes = new();
+            byte partnerCount = 0;
             foreach (var node in nodes)
                 if (node.Relation == RelationType.Partner)
-                    partnerNodes.Add(node);
-            float xPos = nodes[0].Rect.x + nodeSize.x * (1.5f + partnerNodes.Count * 1.5f);
+                    partnerCount++;
+            float xPos = nodes[0].Rect.x + nodeSize.x * (1.5f + partnerCount * 1.5f);
             float yPos = nodes[0].Rect.y + 45 / 2;
             Node partnerNode = NewNode(xPos, yPos, RelationType.Partner);
             CreateLink(partnerNode, nodes[0], CurveAnchor.Left);
@@ -262,16 +275,17 @@ namespace KL
         #endregion
 
         #region Children
-        void AddChildrenNode()
+        void AddChildrenNode(Node parentNode)
         {
-            List<Node> childNodes = new();
-            foreach (var node in nodes)
-                if (node.Relation == RelationType.Children)
-                    childNodes.Add(node);
-            float xPos = nodes[0].Rect.x;
-            float yPos = nodes[0].Rect.y + nodeSize.y * (2f + childNodes.Count * 2f);
+            byte linkCount = 0;
+            foreach (var pair in links)
+                if (pair.Value.Node.Equals(parentNode))
+                    linkCount++;
+
+            float xPos = parentNode.Rect.x;
+            float yPos = nodes[0].Rect.y + nodeSize.y * (2f + linkCount * 2f);
             Node childNode = NewNode(xPos, yPos, RelationType.Children);
-            CreateLink(childNode, nodes[0], CurveAnchor.Top);
+            CreateLink(childNode, parentNode, CurveAnchor.Top);
         }
         #endregion
         void DrawNode(int id)
@@ -294,7 +308,6 @@ namespace KL
                         foreach (var node in nodes)
                             if (node.Relation == RelationType.Parent)
                                 parentNodes.Add(node);
-                        Debug.LogError("partnerNodes count " + parentNodes.Count);
                         if (parentNodes.Count < 2)
                         {
                             if (GUILayout.Button(RelationType.Parent.ToString()))
@@ -303,7 +316,7 @@ namespace KL
                         if (GUILayout.Button(RelationType.Partner.ToString()))
                             AddPartnerNode();
                         if (GUILayout.Button(RelationType.Children.ToString()))
-                            AddChildrenNode();
+                            AddChildrenNode(nodes[0]);
                         if (!isRootGenerated) InitializeNodes();
                     }
             }
@@ -318,7 +331,7 @@ namespace KL
                             if (nodes[id].Relation == RelationType.Partner)
                             {
                                 if (GUILayout.Button("Add Child", GUILayout.ExpandWidth(true)))
-                                    relationType = RelationType.Children;
+                                    AddChildrenNode(nodes[id]);
                             }
                             if (GUILayout.Button("Remove", GUILayout.ExpandWidth(true)))
                                 DeleteLink(id);
@@ -434,11 +447,13 @@ namespace KL
                 PolityMember key = polityMembers[keyIndex];
                 int valueIndex = linkToRemoveValue.Index;
                 PolityMember value = polityMembers[valueIndex];
-
-                if (key.family.parents.Contains(value))
-                    key.family.parents.Remove(value);
-                if (value.family.parents.Contains(key))
-                    value.family.parents.Remove(key);
+                if (key != null && value != null)
+                {
+                    if (key.family.parents.Contains(value))
+                        key.family.parents.Remove(value);
+                    if (value.family.parents.Contains(key))
+                        value.family.parents.Remove(key);
+                }
 
             }
             links.Remove(linkToRemoveKey);

--- a/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
+++ b/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
@@ -8,7 +8,7 @@ namespace KL
     public class PolityFamilyGraph : EditorWindow
     {
         /* ---------------------------- POLITY VARIABLES ---------------------------- */
-        enum NodeAnchor
+        enum CurveAnchor
         {
             Top,
             Right,
@@ -30,40 +30,31 @@ namespace KL
         struct Node
         {
             public Rect Rect;
+            public RelationType Relation;
             // public int NodeId;
-            public NodeAnchor Anchor;
-            public Node(Rect rect, NodeAnchor anchorPoint)
+            public Node(Rect rect, RelationType relationType)
             {
                 Rect = rect;
-                // NodeId = nodeId;
-                Anchor = anchorPoint;
+                Relation = relationType;
             }
         }
         struct Link
         {
-            public Rect Rect;
-            public RelationType Relation;
-            // public int NodeId;
-            public NodeAnchor Anchor;
-            public Link(Rect rect, RelationType relation, NodeAnchor anchorPoint)
+            public Node Node;
+            public int Index;
+            public CurveAnchor Anchor;
+            public Link(Node node, int index, CurveAnchor anchorPoint)
             {
-                Rect = rect;
-                Relation = relation;
-                // NodeId = nodeId;
+                Node = node;
+                Index = index;
                 Anchor = anchorPoint;
             }
-            // public Curve(Rect rect, int nodeId, NodeAnchor anchorPoint)
-            // {
-            //     Rect = rect;
-            //     NodeId = nodeId;
-            //     Anchor = anchorPoint;
-            // }
+
         }
         SerializedObject serializedObject;
         GUIStyle parentNode, partnerNode, childNode;
-        List<Node> nodes2 = new();
-        Dictionary<Rect, RelationType> nodes = new();
-        Dictionary<Node, Node> links = new();
+        List<Node> nodes = new();
+        Dictionary<Link, Link> links = new();
         Vector2 nodeSize = new(140, 65);
         /// <summary>
         /// This nodeId is referenced only in a node which is a child of the root node
@@ -71,7 +62,7 @@ namespace KL
         int childNodeId = -1;
         bool isRootGenerated;
         // Dictionary<Curve, Curve> linkedNodes = new(), linkedChildNodes = new();
-        Dictionary<int, RelationType> linkedRelationType = new();
+        // Dictionary<int, RelationType> linkedRelationType = new();
 
         /* ------------------------------ PAN CONTROLS ------------------------------ */
         float panX = 0, panY = 0;
@@ -90,16 +81,17 @@ namespace KL
             childNode = new GUIStyle(GUI.skin.window);
             childNode.normal.background = EditorGUIUtility.Load("builtin skins/darkskin/images/node1.png") as Texture2D;
 
+            // nodes.Clear();
             nodes.Clear();
             polityMembers.Clear();
             // linkedNodes.Clear();
-            linkedRelationType.Clear();
 
             // Calculate the center of the groupRect
             Vector2 windowCenter = new(position.width / 2, position.height / 2);
             Rect rootNodeRect = new(windowCenter.x + nodeSize.x,
                                     (windowCenter.y / 2) + nodeSize.y / 2, nodeSize.x, 105);
-            nodes.Add(rootNodeRect, RelationType.Root);
+            // nodes.Add(rootNodeRect, RelationType.Root);
+            nodes.Add(new Node(rootNodeRect, RelationType.Root));
         }
 
         public static void ShowWindow()
@@ -141,6 +133,8 @@ namespace KL
             GUI.BeginGroup(groupRect);
             BeginWindows();
 
+            foreach (var pair in links)
+                DrawNodeCurve(pair.Key, pair.Value, pair.Key.Anchor);
             // foreach (var pair in linkedNodes)
             //     DrawNodeCurve(nodeRects.ElementAt(pair.Key.NodeId).Key, nodeRects.ElementAt(pair.Value.NodeId).Key, pair.Key.Point, pair.Value.Point);
             // foreach (var pair in linkedChildNodes)
@@ -148,36 +142,36 @@ namespace KL
             int index = 0;
             foreach (var node in nodes)
             {
-                Rect nodeRect = node.Key;
-                if (node.Value == RelationType.Root)//Root node
+                Rect nodeRect = node.Rect;
+                if (node.Relation == RelationType.Root)//Root node
                 {
                     if (polityMembers.Any() && polityMembers[0] != null)
                     {
                         if (polityMembers[0].family.parents.Count < 2)
-                            nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 115);
-                        else nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 90);
+                            nodeRect = new Rect(node.Rect.x, node.Rect.y, nodeSize.x, 115);
+                        else nodeRect = new Rect(node.Rect.x, node.Rect.y, nodeSize.x, 90);
                     }
-                    nodeRect = GUI.Window(index, node.Key, DrawNode, "Root " + index);
+                    nodeRect = GUI.Window(index, node.Rect, DrawNode, "Root " + index);
                 }
                 else
                 {
-                    switch (node.Value)
+                    switch (node.Relation)
                     {
                         case RelationType.Parent:
-                            DrawNodeCurve(nodes.ElementAt(0).Key, node.Key, NodeAnchor.Top, NodeAnchor.Bottom);
-                            nodeRect = GUI.Window(index, node.Key, DrawNode, "Parent " + index, parentNode);
+                            // DrawNodeCurve(nodes2[0].Rect, node.Rect, NodeAnchor.Top, NodeAnchor.Bottom);
+                            nodeRect = GUI.Window(index, node.Rect, DrawNode, "Parent " + index, parentNode);
                             break;
                         case RelationType.Partner:
-                            nodeRect = GUI.Window(index, node.Key, DrawNode, "Partner " + index, partnerNode);
+                            nodeRect = GUI.Window(index, node.Rect, DrawNode, "Partner " + index, partnerNode);
                             break;
                         case RelationType.Children:
                             if (polityMembers[index] != null)
                             {
                                 if (polityMembers[index].family.parents.Count == 1)
-                                    nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 90);
-                                else nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 65);
+                                    nodeRect = new Rect(node.Rect.x, node.Rect.y, nodeSize.x, 90);
+                                else nodeRect = new Rect(node.Rect.x, node.Rect.y, nodeSize.x, 65);
                             }
-                            nodeRect = GUI.Window(index, node.Key, DrawNode, "Child " + index, childNode);
+                            nodeRect = GUI.Window(index, node.Rect, DrawNode, "Child " + index, childNode);
                             break;
                     }
                 }
@@ -214,13 +208,23 @@ namespace KL
                 }
             }
         }
-        void LinkNodes(Rect rect, NodeAnchor nodeAnchor)
+        void LinkNodes(Node startNode, Node endNode, CurveAnchor anchor)
         {
-            // links.Add(nodes.ElementAt(0).Key, new(rect, nodeAnchor));
+            CurveAnchor endAnchor = GetOppositeAnchor(anchor);
+            int startIndex = nodes.IndexOf(startNode);
+            int endIndex = nodes.IndexOf(endNode);
+            links.Add(new Link(startNode, startIndex, anchor), new Link(endNode, endIndex, endAnchor));
+            foreach (var pair in links)
+            {
+                // DrawNodeCurve(pair.Key.Node.Rect, pair.Value.Node.Rect, pair.Key.Anchor, pair.Value.Anchor);
+                Debug.LogError("link node " + pair.Key.Node.Rect.position + " to " + pair.Value.Node.Rect.position
+                 + " index " + pair.Key.Index + " to " + pair.Value.Index);
+            }
         }
-        void NewNode(float x, float y, RelationType type)
+        Node NewNode(float x, float y, RelationType type)
         {
-            nodes.Add(new Rect(x, y, nodeSize.x, nodeSize.y), type);
+            Node node = new(new Rect(x, y, nodeSize.x, nodeSize.y), type);
+            nodes.Add(node); return node;
         }
         Rect MoveNode(Rect node, float x, float y)
         {
@@ -228,11 +232,11 @@ namespace KL
         }
         void AddParentNode()
         {
-            List<Rect> parentNodes = new();
+            List<Node> parentNodes = new();
             foreach (var node in nodes)
             {
-                if (node.Value == RelationType.Parent)
-                    parentNodes.Add(node.Key);
+                if (node.Relation == RelationType.Parent)
+                    parentNodes.Add(node);
             }
 
             if (polityMembers[0].family.parents.Count < 2 &&
@@ -242,17 +246,19 @@ namespace KL
                 switch (parentNodes.Count)
                 {
                     case 0:
-                        NewNode(nodes.ElementAt(0).Key.x, nodes.ElementAt(0).Key.y - nodeSize.y * 2f, RelationType.Parent);
+                        Node node = NewNode(nodes[0].Rect.x, nodes[0].Rect.y - nodeSize.y * 2f, RelationType.Parent);
+                        LinkNodes(nodes[0], node, CurveAnchor.Top);
                         break;
                     case 1:
-                        Debug.Log("Parent node b4 " + parentNodes[0].position);
-                        Rect movedNode = MoveNode(parentNodes[0], nodes.ElementAt(0).Key.x - nodeSize.x,
-                                                                nodes.ElementAt(0).Key.y - nodeSize.y * 2f);
-                        Debug.Log("Parent node moved to " + parentNodes[0].position);
+                        Debug.Log("Parent node b4 " + parentNodes[0].Rect.position);
+                        Rect movedNode = MoveNode(parentNodes[0].Rect, nodes[0].Rect.x - nodeSize.x,
+                                                                nodes[0].Rect.y - nodeSize.y * 2f);
+                        Debug.Log("Parent node moved to " + parentNodes[0].Rect.position);
                         nodes.Remove(parentNodes[0]);
-                        nodes.Add(movedNode, RelationType.Parent);
-                        NewNode(nodes.ElementAt(0).Key.x + nodeSize.x,
-                                nodes.ElementAt(0).Key.y - nodeSize.y * 2f, RelationType.Parent);
+                        nodes.Add(new Node(movedNode, RelationType.Parent));
+                        Node node1 = NewNode(nodes[0].Rect.x + nodeSize.x,
+                                 nodes[0].Rect.y - nodeSize.y * 2f, RelationType.Parent);
+                        LinkNodes(nodes[0], node1, CurveAnchor.Top);
                         break;
                 }
             }
@@ -285,44 +291,44 @@ namespace KL
                     {
                         SetRootNodeRelationTypes(id);
                         EditorGUILayout.BeginHorizontal();
-                        if (linkedRelationType.ContainsKey(id))
+                        // if (linkedRelationType.ContainsKey(id))
                         {
-                            if (linkedRelationType[id] == RelationType.Partner)
+                            // if (linkedRelationType[id] == RelationType.Partner)
+                            // {
+                            //     if (GUILayout.Button("Attach", GUILayout.ExpandWidth(true)))
+                            //         EstablishNodeConnection(id);
+                            //     if (GUILayout.Button("X", GUILayout.ExpandWidth(false)))
+                            //     { ClearRootNodeRelations(id); DeleteCurveToRootNode(id); }
+                            // }
+                            // else
+                            // {
+                            if (GUILayout.Button("Remove", GUILayout.ExpandWidth(true)))
                             {
-                                if (GUILayout.Button("Attach", GUILayout.ExpandWidth(true)))
-                                    EstablishNodeConnection(id);
-                                if (GUILayout.Button("X", GUILayout.ExpandWidth(false)))
-                                { ClearRootNodeRelations(id); DeleteCurveToRootNode(id); }
+                                DeleteCurveToRootNode(id);
+                                // if (linkedRelationType[id] == RelationType.Children)
+                                // {
+                                //     PolityMember root = polityMembers[0];
+                                //     for (int i = 0; i < root.family.partners.Count; i++)
+                                //         for (int x = 0; x < root.family.partners[i].children.Length; x++)
+                                //             if (root.family.partners[i].children[x] == polityMembers[id])
+                                //             {
+                                //                 childNodeId = polityMembers.IndexOf(root.family.partners[i].partner);
+                                //                 DeleteCurveToParentNode(id);
+                                //                 ClearChildNodeRelation(id);
+                                //                 break;
+                                //             }
+                                // }
+                                ClearRootNodeRelations(id);
                             }
-                            else
-                            {
-                                if (GUILayout.Button("Detach", GUILayout.ExpandWidth(true)))
-                                {
-                                    DeleteCurveToRootNode(id);
-                                    if (linkedRelationType[id] == RelationType.Children)
-                                    {
-                                        PolityMember root = polityMembers[0];
-                                        for (int i = 0; i < root.family.partners.Count; i++)
-                                            for (int x = 0; x < root.family.partners[i].children.Length; x++)
-                                                if (root.family.partners[i].children[x] == polityMembers[id])
-                                                {
-                                                    childNodeId = polityMembers.IndexOf(root.family.partners[i].partner);
-                                                    DeleteCurveToParentNode(id);
-                                                    ClearChildNodeRelation(id);
-                                                    break;
-                                                }
-                                    }
-                                    ClearRootNodeRelations(id);
-                                }
-                            }
+                            // }
                         }
-                        else
-                        {
-                            if (GUILayout.Button("Attach", GUILayout.ExpandWidth(true)))
-                                EstablishNodeConnection(id);
-                        }
+                        // else
+                        // {
+                        //     if (GUILayout.Button("Attach", GUILayout.ExpandWidth(true)))
+                        //         EstablishNodeConnection(id);
+                        // }
                         EditorGUILayout.EndHorizontal();
-                        if (polityMembers[id] != null && nodes.ElementAt(id).Key != null)
+                        if (polityMembers[id] != null && nodes[0].Rect != null)
                             if (polityMembers[id].family.parents.Contains(polityMembers[0]) && polityMembers[id].family.parents.Count < 2)
                                 if (GUILayout.Button("Parent")) childNodeId = id;
                     }
@@ -356,7 +362,7 @@ namespace KL
             }
 
 
-            Rect rootNode = nodes.ElementAt(0).Key;
+            Rect rootNode = nodes[0].Rect;
             float currentXOffset;
             #region Parents
             /* -------------------------- Building Parent Nodes ------------------------- */
@@ -420,7 +426,7 @@ namespace KL
         void AttachCurveToRootNode(int id) => AttachCurveToNode(0, id);
         void AttachCurveToNode(int rootId, int id)
         {
-            if (linkedRelationType.ContainsKey(id)) return;
+            // if (linkedRelationType.ContainsKey(id)) return;
             // Curve root, target;
             switch (relationType)
             {
@@ -500,43 +506,43 @@ namespace KL
                 return;
             }
             if (polityMembers[id] == null) return;
-            if (linkedRelationType.TryGetValue(id, out RelationType relation))
-            {
-                switch (relation)
-                {
-                    case RelationType.Parent:
-                        if (!polityMembers[rootId].family.parents.Contains(polityMembers[id]))
-                            polityMembers[rootId].family.parents.Add(polityMembers[id]);
-                        // if (!polityMembers[id].children.Contains(polityMembers[rootId]))
-                        //     polityMembers[id].children.Add(polityMembers[rootId]);
-                        break;
-                    case RelationType.Partner:
-                        if (rootId != 0)//This is a child to partner, i.e child to parent 
-                        {
-                            if (!polityMembers[rootId].family.parents.Contains(polityMembers[id]))
-                                polityMembers[rootId].family.parents.Add(polityMembers[id]);
-                            // if (!polityMembers[id].children.Contains(polityMembers[rootId]))
-                            //     polityMembers[id].children.Add(polityMembers[rootId]);
-                        }
-                        else
-                        {
-                            // if (!polityMembers[rootId].family.partners.Contains(polityMembers[id]))
-                            //     polityMembers[rootId].family.partners.Add(polityMembers[id]);
-                            // if (!polityMembers[id].partners.Contains(polityMembers[rootId]))
-                            //     polityMembers[id].partners.Add(polityMembers[rootId]);
-                        }
-                        break;
-                    case RelationType.Children:
-                        // if (!polityMembers[rootId].children.Contains(polityMembers[id]))
-                        //     polityMembers[rootId].children.Add(polityMembers[id]);
-                        // if (!polityMembers[id].parents.Contains(polityMembers[rootId]))
-                        //     polityMembers[id].parents.Add(polityMembers[rootId]);
-                        break;
-                    default:
-                        Debug.Log("Unknown relationship.");
-                        break;
-                }
-            }
+            // if (linkedRelationType.TryGetValue(id, out RelationType relation))
+            // {
+            //     switch (relation)
+            //     {
+            //         case RelationType.Parent:
+            //             if (!polityMembers[rootId].family.parents.Contains(polityMembers[id]))
+            //                 polityMembers[rootId].family.parents.Add(polityMembers[id]);
+            //             // if (!polityMembers[id].children.Contains(polityMembers[rootId]))
+            //             //     polityMembers[id].children.Add(polityMembers[rootId]);
+            //             break;
+            //         case RelationType.Partner:
+            //             if (rootId != 0)//This is a child to partner, i.e child to parent 
+            //             {
+            //                 if (!polityMembers[rootId].family.parents.Contains(polityMembers[id]))
+            //                     polityMembers[rootId].family.parents.Add(polityMembers[id]);
+            //                 // if (!polityMembers[id].children.Contains(polityMembers[rootId]))
+            //                 //     polityMembers[id].children.Add(polityMembers[rootId]);
+            //             }
+            //             else
+            //             {
+            //                 // if (!polityMembers[rootId].family.partners.Contains(polityMembers[id]))
+            //                 //     polityMembers[rootId].family.partners.Add(polityMembers[id]);
+            //                 // if (!polityMembers[id].partners.Contains(polityMembers[rootId]))
+            //                 //     polityMembers[id].partners.Add(polityMembers[rootId]);
+            //             }
+            //             break;
+            //         case RelationType.Children:
+            //             // if (!polityMembers[rootId].children.Contains(polityMembers[id]))
+            //             //     polityMembers[rootId].children.Add(polityMembers[id]);
+            //             // if (!polityMembers[id].parents.Contains(polityMembers[rootId]))
+            //             //     polityMembers[id].parents.Add(polityMembers[rootId]);
+            //             break;
+            //         default:
+            //             Debug.Log("Unknown relationship.");
+            //             break;
+            //     }
+            // }
             // else Debug.LogWarning("No relation found for ID: " + id);
         }
 
@@ -554,31 +560,31 @@ namespace KL
         }
         void ClearLinkedNodeRelations(int rootId, int id)
         {
-            if (linkedRelationType.ContainsKey(id))
-            {
-                switch (linkedRelationType[id])
-                {
-                    case RelationType.Partner:
-                        // if (polityMembers[rootId].partners.Contains(polityMembers[id]))
-                        //     polityMembers[rootId].partners.Remove(polityMembers[id]);
-                        // if (polityMembers[id].partners.Contains(polityMembers[rootId]))
-                        //     polityMembers[id].partners.Remove(polityMembers[rootId]);
-                        break;
-                    case RelationType.Parent:
-                        if (polityMembers[rootId].family.parents.Contains(polityMembers[id]))
-                            polityMembers[rootId].family.parents.Remove(polityMembers[id]);
-                        // if (polityMembers[id].children.Contains(polityMembers[rootId]))
-                        //     polityMembers[id].children.Remove(polityMembers[rootId]);
-                        break;
-                    case RelationType.Children:
-                        // if (polityMembers[rootId].children.Contains(polityMembers[id]))
-                        //     polityMembers[rootId].children.Remove(polityMembers[id]);
-                        if (polityMembers[id].family.parents.Contains(polityMembers[rootId]))
-                            polityMembers[id].family.parents.Remove(polityMembers[rootId]);
-                        break;
-                }
-                linkedRelationType.Remove(id);
-            }
+            // if (linkedRelationType.ContainsKey(id))
+            // {
+            //     switch (linkedRelationType[id])
+            //     {
+            //         case RelationType.Partner:
+            //             if (polityMembers[rootId].family.partners.Any(p => p.partner == polityMembers[id]))
+            //                 polityMembers[rootId].family.partners.RemoveAll(p => p.partner == polityMembers[id]);
+            //             if (polityMembers[id].family.partners.Any(p => p.partner == polityMembers[rootId]))
+            //                 polityMembers[id].family.partners.RemoveAll(p => p.partner == polityMembers[rootId]);
+            //             break;
+            //         case RelationType.Parent:
+            //             if (polityMembers[rootId].family.parents.Contains(polityMembers[id]))
+            //                 polityMembers[rootId].family.parents.Remove(polityMembers[id]);
+            //             // if (polityMembers[id].children.Contains(polityMembers[rootId]))
+            //             //     polityMembers[id].children.Remove(polityMembers[rootId]);
+            //             break;
+            //         case RelationType.Children:
+            //             // if (polityMembers[rootId].children.Contains(polityMembers[id]))
+            //             //     polityMembers[rootId].children.Remove(polityMembers[id]);
+            //             if (polityMembers[id].family.parents.Contains(polityMembers[rootId]))
+            //                 polityMembers[id].family.parents.Remove(polityMembers[rootId]);
+            //             break;
+            //     }
+            //     linkedRelationType.Remove(id);
+            // }
         }
         void ClearRootNodeRelations(int id) => ClearLinkedNodeRelations(0, id);
 
@@ -601,50 +607,75 @@ namespace KL
             return isDuplicate;
         }
 
+        #region Curve Links
         /* -------------------------------------------------------------------------- */
         /*                            Bezier Curve Drawers                            */
         /* -------------------------------------------------------------------------- */
-        void DrawNodeCurve(Rect start, Rect end, NodeAnchor startConnection, NodeAnchor endConnection)
-        {
-            Vector2 startPercentage = GetPercentageFromConnectionPoint(startConnection);
-            Vector2 endPercentage = GetPercentageFromConnectionPoint(endConnection);
-            Color lineColor = GetStartConnectionLineColor(startConnection);
-            DrawNodeCurve(start, end, startPercentage, endPercentage, lineColor);
-        }
-        Vector2 GetPercentageFromConnectionPoint(NodeAnchor point)
-        {
-            return point switch
+        CurveAnchor GetOppositeAnchor(CurveAnchor anchor)
+            => anchor switch
             {
-                NodeAnchor.Top => new Vector2(0.5f, 0f),
-                NodeAnchor.Right => new Vector2(1.0f, 0.5f),
-                NodeAnchor.Left => new Vector2(0.0f, 0.5f),
-                NodeAnchor.Bottom => new Vector2(0.5f, 1f),
-                NodeAnchor.Child => new Vector2(0.5f, 1f),
-                _ => new Vector2(0.5f, 0.5f),// Default to center if unknown for some reason
+                CurveAnchor.Top => CurveAnchor.Bottom,
+                CurveAnchor.Right => CurveAnchor.Left,
+                CurveAnchor.Left => CurveAnchor.Right,
+                CurveAnchor.Bottom => CurveAnchor.Top,
+                _ => CurveAnchor.Child,
             };
-        }
-        Color GetStartConnectionLineColor(NodeAnchor startConnection)
-        {
-            return startConnection switch
+
+        Vector2 GetNodeAnchorVector(CurveAnchor point)
+            => point switch
             {
-                NodeAnchor.Top => Color.blue,
-                NodeAnchor.Right => Color.green,
-                NodeAnchor.Left => Color.green,
-                NodeAnchor.Bottom => Color.red,
-                NodeAnchor.Child => Color.cyan,
+                CurveAnchor.Top => new(0.5f, 0f),
+                CurveAnchor.Right => new(1.0f, 0.5f),
+                CurveAnchor.Left => new(0.0f, 0.5f),
+                CurveAnchor.Bottom => new(0.5f, 1f),
+                CurveAnchor.Child => new(0.5f, 1f),
+                _ => new(0.5f, 0.5f),
+            };
+        void DrawNodeCurve(Node start, Node end, CurveAnchor startAnchor)
+        {
+            CurveAnchor endAnchor = GetOppositeAnchor(startAnchor);
+            Vector2 startPos = GetNodeAnchorVector(startAnchor);
+            Vector2 endPos = GetNodeAnchorVector(endAnchor);
+            Color lineColor = GetAnchorLineColor(startAnchor, 0);
+            DrawNodeCurve(start.Rect, end.Rect, startPos, endPos, lineColor);
+        }
+
+        void DrawNodeCurve(Link start, Link end, CurveAnchor startAnchor)
+        {
+            CurveAnchor endAnchor = GetOppositeAnchor(startAnchor);
+            Vector2 startPos = GetNodeAnchorVector(startAnchor);
+            Vector2 endPos = GetNodeAnchorVector(endAnchor);
+            Color lineColor = GetAnchorLineColor(startAnchor, end.Index);
+            DrawNodeCurve(start.Node.Rect, end.Node.Rect, startPos, endPos, lineColor);
+        }
+
+        Color GetAnchorLineColor(CurveAnchor startAnchor, int endIndex)
+        {
+            if (endIndex < 0 || endIndex >= polityMembers.Count || polityMembers[endIndex] == null)
+            {
+                return Color.white;
+            }
+            return startAnchor switch
+            {
+                CurveAnchor.Top => Color.blue,
+                CurveAnchor.Right => Color.green,
+                CurveAnchor.Left => Color.green,
+                CurveAnchor.Bottom => Color.red,
+                CurveAnchor.Child => Color.cyan,
                 _ => Color.black,// Default to center if unknown for some reason
             };
         }
-        void DrawNodeCurve(Rect start, Rect end, Vector2 vStartPercentage, Vector2 vEndPercentage, Color lineColor)
+        void DrawNodeCurve(Rect start, Rect end, Vector2 startVector, Vector2 endVector, Color lineColor)
         {
-            Vector3 startPos = new(start.x + start.width * vStartPercentage.x, start.y + start.height * vStartPercentage.y, 0);
-            Vector3 endPos = new(end.x + end.width * vEndPercentage.x, end.y + end.height * vEndPercentage.y, 0);
-            Vector3 startTan = startPos + Vector3.right * (-50 + 100 * vStartPercentage.x) + Vector3.up * (-50 + 100 * vStartPercentage.y);
-            Vector3 endTan = endPos + Vector3.right * (-50 + 100 * vEndPercentage.x) + Vector3.up * (-50 + 100 * vEndPercentage.y);
+            Vector3 startPos = new(start.x + start.width * startVector.x, start.y + start.height * startVector.y, 0);
+            Vector3 endPos = new(end.x + end.width * endVector.x, end.y + end.height * endVector.y, 0);
+            Vector3 startTan = startPos + Vector3.right * (-50 + 100 * startVector.x) + Vector3.up * (-50 + 100 * startVector.y);
+            Vector3 endTan = endPos + Vector3.right * (-50 + 100 * endVector.x) + Vector3.up * (-50 + 100 * endVector.y);
             Color shadowCol = new(200, 200, 200, .25f);
             for (int i = 0; i < 3; i++) // Draw a shadow
                 Handles.DrawBezier(startPos, endPos, startTan, endTan, shadowCol, null, (i + 1) * 5);
             Handles.DrawBezier(startPos, endPos, startTan, endTan, lineColor, null, 2);
         }
     }
+    #endregion
 }

--- a/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
+++ b/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
@@ -59,10 +59,7 @@ namespace KL
         /// <summary>
         /// This nodeId is referenced only in a node which is a child of the root node
         /// </summary>
-        int childNodeId = -1;
         bool isRootGenerated;
-        // Dictionary<Curve, Curve> linkedNodes = new(), linkedChildNodes = new();
-        // Dictionary<int, RelationType> linkedRelationType = new();
 
         /* ------------------------------ PAN CONTROLS ------------------------------ */
         float panX = 0, panY = 0;
@@ -135,10 +132,6 @@ namespace KL
 
             foreach (var pair in links)
                 DrawNodeCurve(pair.Key, pair.Value, pair.Key.Anchor);
-            // foreach (var pair in linkedNodes)
-            //     DrawNodeCurve(nodeRects.ElementAt(pair.Key.NodeId).Key, nodeRects.ElementAt(pair.Value.NodeId).Key, pair.Key.Point, pair.Value.Point);
-            // foreach (var pair in linkedChildNodes)
-            //     DrawNodeCurve(nodeRects.ElementAt(pair.Value.NodeId).Key, nodeRects.ElementAt(pair.Key.NodeId).Key, pair.Value.Point, pair.Key.Point);
             int index = 0;
             foreach (var node in nodes)
             {
@@ -208,27 +201,35 @@ namespace KL
                 }
             }
         }
-        void LinkNodes(Node startNode, Node endNode, CurveAnchor anchor)
-        {
-            CurveAnchor endAnchor = GetOppositeAnchor(anchor);
-            int startIndex = nodes.IndexOf(startNode);
-            int endIndex = nodes.IndexOf(endNode);
-            links.Add(new Link(startNode, startIndex, anchor), new Link(endNode, endIndex, endAnchor));
-            foreach (var pair in links)
-            {
-                // DrawNodeCurve(pair.Key.Node.Rect, pair.Value.Node.Rect, pair.Key.Anchor, pair.Value.Anchor);
-                Debug.LogError("link node " + pair.Key.Node.Rect.position + " to " + pair.Value.Node.Rect.position
-                 + " index " + pair.Key.Index + " to " + pair.Value.Index);
-            }
-        }
+        #region Nodes
         Node NewNode(float x, float y, RelationType type)
         {
             Node node = new(new Rect(x, y, nodeSize.x, nodeSize.y), type);
             nodes.Add(node); return node;
         }
-        Rect MoveNode(Rect node, float x, float y)
+        void MoveNode(Node node, float x, float y)
         {
-            return new Rect(x, y, node.width, node.height);
+            int nodeIndex = nodes.IndexOf(node);
+            if (nodeIndex < 0 || nodeIndex >= nodes.Count)
+            {
+                Debug.LogError("Invalid node index");
+                return;
+            }
+            Node oldNode = nodes[nodeIndex];
+            Rect newRect = new Rect(x, y, oldNode.Rect.width, oldNode.Rect.height);
+            Node newNode = new Node(newRect, oldNode.Relation);
+            nodes[nodeIndex] = new Node(newRect, oldNode.Relation);
+
+            // Transfer the polityMembers reference if it exists
+            if (nodeIndex < polityMembers.Count && polityMembers[nodeIndex] != null)
+                polityMembers[nodeIndex] = polityMembers[nodeIndex];
+            MoveLink(nodeIndex, newNode);
+        }
+
+        void RemoveNode(Node node)
+        {
+            polityMembers.RemoveAt(nodes.IndexOf(node));
+            nodes.Remove(node);
         }
         void AddParentNode()
         {
@@ -238,27 +239,20 @@ namespace KL
                 if (node.Relation == RelationType.Parent)
                     parentNodes.Add(node);
             }
-
             if (polityMembers[0].family.parents.Count < 2 &&
                 parentNodes.Count < 2)
             {
-                relationType = RelationType.Parent;
                 switch (parentNodes.Count)
                 {
                     case 0:
                         Node node = NewNode(nodes[0].Rect.x, nodes[0].Rect.y - nodeSize.y * 2f, RelationType.Parent);
-                        LinkNodes(nodes[0], node, CurveAnchor.Top);
+                        CreateLink(node, nodes[0], CurveAnchor.Bottom);
                         break;
                     case 1:
-                        Debug.Log("Parent node b4 " + parentNodes[0].Rect.position);
-                        Rect movedNode = MoveNode(parentNodes[0].Rect, nodes[0].Rect.x - nodeSize.x,
-                                                                nodes[0].Rect.y - nodeSize.y * 2f);
-                        Debug.Log("Parent node moved to " + parentNodes[0].Rect.position);
-                        nodes.Remove(parentNodes[0]);
-                        nodes.Add(new Node(movedNode, RelationType.Parent));
+                        MoveNode(parentNodes[0], nodes[0].Rect.x - nodeSize.x, nodes[0].Rect.y - nodeSize.y * 2f);
                         Node node1 = NewNode(nodes[0].Rect.x + nodeSize.x,
                                  nodes[0].Rect.y - nodeSize.y * 2f, RelationType.Parent);
-                        LinkNodes(nodes[0], node1, CurveAnchor.Top);
+                        CreateLink(node1, nodes[0], CurveAnchor.Bottom);
                         break;
                 }
             }
@@ -268,7 +262,12 @@ namespace KL
             while (polityMembers.Count <= id) polityMembers.Add(null);
             EditorGUI.BeginChangeCheck();
             polityMembers[id] = EditorGUILayout.ObjectField("", polityMembers[id], typeof(PolityMember), false) as PolityMember;
-            if (EditorGUI.EndChangeCheck()) serializedObject.ApplyModifiedProperties();
+            if (EditorGUI.EndChangeCheck())
+            {
+                Debug.Log("polity members have been changed " + polityMembers[id].name);
+                LinkFamily(id);
+                serializedObject.ApplyModifiedProperties();
+            }
             if (id == 0)
             {
                 if (polityMembers[0] != null && PrefabUtility.IsPartOfPrefabAsset(polityMembers[0]))
@@ -280,7 +279,7 @@ namespace KL
                             relationType = RelationType.Partner;
                         if (GUILayout.Button(RelationType.Children.ToString()))
                             relationType = RelationType.Children;
-                        if (!isRootGenerated) DrawRootNode();
+                        if (!isRootGenerated) InitializeNodes();
                     }
             }
             else
@@ -289,93 +288,166 @@ namespace KL
                 {
                     if (!CheckForDuplicateNode(id))
                     {
-                        SetRootNodeRelationTypes(id);
                         EditorGUILayout.BeginHorizontal();
-                        // if (linkedRelationType.ContainsKey(id))
                         {
-                            // if (linkedRelationType[id] == RelationType.Partner)
-                            // {
-                            //     if (GUILayout.Button("Attach", GUILayout.ExpandWidth(true)))
-                            //         EstablishNodeConnection(id);
-                            //     if (GUILayout.Button("X", GUILayout.ExpandWidth(false)))
-                            //     { ClearRootNodeRelations(id); DeleteCurveToRootNode(id); }
-                            // }
-                            // else
-                            // {
                             if (GUILayout.Button("Remove", GUILayout.ExpandWidth(true)))
-                            {
-                                DeleteCurveToRootNode(id);
-                                // if (linkedRelationType[id] == RelationType.Children)
-                                // {
-                                //     PolityMember root = polityMembers[0];
-                                //     for (int i = 0; i < root.family.partners.Count; i++)
-                                //         for (int x = 0; x < root.family.partners[i].children.Length; x++)
-                                //             if (root.family.partners[i].children[x] == polityMembers[id])
-                                //             {
-                                //                 childNodeId = polityMembers.IndexOf(root.family.partners[i].partner);
-                                //                 DeleteCurveToParentNode(id);
-                                //                 ClearChildNodeRelation(id);
-                                //                 break;
-                                //             }
-                                // }
-                                ClearRootNodeRelations(id);
-                            }
-                            // }
+                                DeleteLink(id);
                         }
-                        // else
-                        // {
-                        //     if (GUILayout.Button("Attach", GUILayout.ExpandWidth(true)))
-                        //         EstablishNodeConnection(id);
-                        // }
                         EditorGUILayout.EndHorizontal();
-                        if (polityMembers[id] != null && nodes[0].Rect != null)
-                            if (polityMembers[id].family.parents.Contains(polityMembers[0]) && polityMembers[id].family.parents.Count < 2)
-                                if (GUILayout.Button("Parent")) childNodeId = id;
                     }
                 }
             }
             // GUI.DragWindow();
         }
+        #endregion
 
-        void EstablishNodeConnection(int id)
+        #region  Links
+        void CreateLink(Node startNode, Node endNode, CurveAnchor anchor)
         {
-            if (childNodeId == -1) { AttachCurveToRootNode(id); SetRootNodeRelationTypes(id); }
-            else
-            { AttachCurveToParentNode(id); SetNodeRelationTypes(childNodeId, id); childNodeId = -1; }
+            CurveAnchor endAnchor = GetOppositeAnchor(anchor);
+            int startIndex = nodes.IndexOf(startNode);
+            int endIndex = nodes.IndexOf(endNode);
+            links.Add(new(startNode, startIndex, anchor), new(endNode, endIndex, endAnchor));
+            Debug.Log("start Index " + startIndex + " end Index " + endIndex);
+
+            foreach (var pair in links)
+            {
+                // DrawNodeCurve(pair.Key.Node.Rect, pair.Value.Node.Rect, pair.Key.Anchor, pair.Value.Anchor);
+                Debug.Log("link node " + pair.Key.Node.Rect.position + " to " + pair.Value.Node.Rect.position
+                 + " index " + pair.Key.Index + " to " + pair.Value.Index);
+            }
+        }
+
+        void MoveLink(int nodeIndex, Node newNode)
+        {
+            List<Link> keysToUpdate = new();
+            foreach (var pair in links)
+                if (pair.Key.Index == nodeIndex)
+                    keysToUpdate.Add(pair.Key);
+
+            foreach (var key in keysToUpdate)
+            {
+                Link value = links[key];
+                links.Remove(key);
+                links.Add(new Link(newNode, key.Index, key.Anchor), value);
+            }
+        }
+        void LinkFamily(int id)
+        {
+            PolityMember member = polityMembers[id];
+            PolityMember valueMember = null;
+            // if (polityMembers[id] != null)
+            // {
+            //     Debug.LogError("PolityMember " + key.name + " is null");
+            //     return;
+            // }
+            foreach (var pair in links)
+            {
+                if (pair.Key.Index == id)
+                {
+                    valueMember = polityMembers[pair.Value.Index];
+                    break;
+                }
+            }
+            if (valueMember != null)
+            {
+                Debug.Log("polity Member and Key " + member + " " + valueMember);
+                switch (nodes[id].Relation)
+                {
+                    case RelationType.Parent:
+                        bool partnerFound = false;
+                        for (int i = 0; i < member.family.partners.Count; i++)
+                        {
+                            if (member.family.partners[i].partner == valueMember)
+                            {
+                                if (!member.family.partners[i].children.Contains(valueMember))
+                                    member.family.partners[i].children.Add(valueMember);
+                                partnerFound = true;
+                                break;
+                            }
+                        }
+
+                        if (!partnerFound)
+                        {
+                            PolityFamily.FamilyStruct.PartnerStruct newPartner = new()
+                            {
+                                children = new List<PolityMember> { valueMember }
+                            };
+                            member.family.partners.Add(newPartner);
+                        }
+
+                        if (!valueMember.family.parents.Contains(member))
+                            valueMember.family.parents.Add(member);
+                        break;
+                }
+            }
+
+        }
+        void DeleteLink(int id, bool deleteFamily = true)
+        {
+            Link linkToRemoveKey = new();
+            Link linkToRemoveValue = new();
+            foreach (var pair in links)
+                if (pair.Key.Index == id)
+                {
+                    linkToRemoveKey = pair.Key;
+                    linkToRemoveValue = pair.Value;
+                    break;
+                }
+            Debug.Log("Deleting link with ID " + id + "link key " + linkToRemoveKey.Index + " link value " + linkToRemoveValue.Index);
+
+            if (deleteFamily)
+            {
+                int keyIndex = linkToRemoveKey.Index;
+                PolityMember key = polityMembers[keyIndex];
+                int valueIndex = linkToRemoveValue.Index;
+                PolityMember value = polityMembers[valueIndex];
+
+                if (key.family.parents.Contains(value))
+                    key.family.parents.Remove(value);
+                if (value.family.parents.Contains(key))
+                    value.family.parents.Remove(key);
+
+            }
+            links.Remove(linkToRemoveKey);
+            RemoveNode(linkToRemoveKey.Node);
+            // foreach (var key in keysToRemove)
+            //     linkedNodes.Remove(key);
+            // if (keysToRemove.Count > 0)
+            // Debug.Log("Removed " + keysToRemove.Count + " connections with ID " + id);
         }
 
         /* -------------------------------------------------------------------------- */
         /*                             NODE INITIALIZATION                            */
         /* -------------------------------------------------------------------------- */
-        void DrawRootNode()
+        void InitializeNodes()
         {
             if (polityMembers[0] == null) return;
             PolityMember root = polityMembers[0];
             root.family.parents = root.family.parents.Where(item => item != null).ToList();
-            root.family.partners = root.family.partners.Where(item => item.partner != null).ToList();
+            // root.family.partners = root.family.partners.Where(item => item.partner != null).ToList();
             // Clean up children for each partner
             for (int i = 0; i < root.family.partners.Count; i++)
             {
                 var partner = root.family.partners[i];
-                partner.children = partner.children.Where(item => item != null).ToArray();
+                // partner.children = partner.children.Where(item => item != null).ToArray();
                 root.family.partners[i] = partner;
             }
 
 
-            Rect rootNode = nodes[0].Rect;
+            Rect rootRect = nodes[0].Rect;
             float currentXOffset;
             #region Parents
             /* -------------------------- Building Parent Nodes ------------------------- */
             for (int i = 0; i < root.family.parents.Count; i++)
             {
-                currentXOffset = -nodeSize.x;
-                polityMembers.Add(root.family.parents[i]);
+                currentXOffset = 0;
                 if (i != 0) currentXOffset += nodeSize.x * 2f;
-                NewNode(rootNode.x + currentXOffset, rootNode.y - nodeSize.y * 2f, RelationType.Parent);
-                relationType = RelationType.Parent;
-                AttachCurveToRootNode(i + 1);
+                Node parentNode = NewNode(rootRect.x + currentXOffset, rootRect.y - nodeSize.y * 2f, RelationType.Parent);
+                CreateLink(parentNode, nodes[0], CurveAnchor.Bottom);
+                polityMembers.Add(root.family.parents[i]);
             }
-            currentXOffset = nodeSize.x * 2f;
+            // currentXOffset = nodeSize.x * 2f;
             #endregion
 
             #region Partners
@@ -383,13 +455,10 @@ namespace KL
             List<int> partnersIds = new();
             for (int i = 0; i < root.family.partners.Count; i++)
             {
-                polityMembers.Add(root.family.partners[i].partner);
+                currentXOffset = -nodeSize.x;
                 if (i != 0) currentXOffset += nodeSize.x * 2f;
-                // nodes.Add(NewNode(rootNode.x + currentXOffset, rootNode.y * 1.05f), RelationType.Partners);
-                NewNode(rootNode.x + currentXOffset, rootNode.y * 1.05f, RelationType.Partner);
-                relationType = RelationType.Partner;
-                AttachCurveToRootNode(polityMembers.Count - 1);
-                partnersIds.Add(polityMembers.Count - 1);
+                Node partnerNode = NewNode(rootRect.x + currentXOffset, +nodeSize.y * 2f, RelationType.Partner);
+                CreateLink(partnerNode, nodes[0], CurveAnchor.Top);
             }
             currentXOffset = nodeSize.x / 2;
             #endregion
@@ -418,176 +487,8 @@ namespace KL
             isRootGenerated = true;
         }
 
-        /* -------------------------------------------------------------------------- */
-        /*                              NODE CONNECTIONS                              */
-        /* -------------------------------------------------------------------------- */
-
-        /* -------------------------- Node Curve Attachment ------------------------- */
-        void AttachCurveToRootNode(int id) => AttachCurveToNode(0, id);
-        void AttachCurveToNode(int rootId, int id)
-        {
-            // if (linkedRelationType.ContainsKey(id)) return;
-            // Curve root, target;
-            switch (relationType)
-            {
-                case RelationType.Parent:
-                default:
-                    // root = new Node(rootId, NodeAnchor.Top);
-                    // target = new Node(id, NodeAnchor.Bottom);
-                    break;
-                case RelationType.Partner:
-                    // root = new Node(rootId, NodeAnchor.Right);
-                    // target = new Node(id, NodeAnchor.Left);
-                    break;
-                case RelationType.Children:
-                    // root = new Node(rootId, NodeAnchor.Bottom);
-                    // target = new Node(id, NodeAnchor.Top);
-                    break;
-            }
-            // if (linkedNodes.ContainsKey(target))
-            //     linkedNodes[target] = root;
-            // else
-            //     linkedNodes.Add(target, root);
-            // if (linkedRelationType.ContainsKey(id))
-            //     linkedRelationType[id] = relationType;
-            // else
-            //     linkedRelationType.Add(id, relationType);
-        }
-        void AttachCurveToParentNode(int id)
-        {
-            // Node root = new(childNodeId, NodeAnchor.Top), target = new(id, NodeAnchor.Child);
-            // if (linkedRelationType.ContainsKey(id))
-            //     if (linkedRelationType[id] == RelationType.Partner)
-            //     {
-            //         if (linkedChildNodes.TryGetValue(target, out Node _target) && _target.Equals(target))
-            //         { Debug.LogWarning("PolityMember pair already exists."); return; }
-            //         else linkedChildNodes.Add(root, target);
-            //     }
-            //     else Debug.LogWarning("A child relation can only be made to a Partner.");
-        }
-
-        /* -------------------------- Node Curve Detachment ------------------------- */
-        void DeleteCurveToNode(int rootId, int id)
-        {
-            // List<Curve> keysToRemove = new();
-            // foreach (var pair in linkedNodes)
-            //     if (pair.Key.NodeId == id && pair.Value.NodeId == rootId)
-            //         keysToRemove.Add(pair.Key);
-
-            // foreach (var key in keysToRemove)
-            //     linkedNodes.Remove(key);
-            // if (keysToRemove.Count > 0)
-            // Debug.Log("Removed " + keysToRemove.Count + " connections with ID " + id);
-        }
-        void DeleteCurveToRootNode(int id) => DeleteCurveToNode(0, id);
-        void DeleteCurveToParentNode(int id)
-        {
-            // List<Curve> keysToRemove = new();
-            // foreach (var pair in linkedChildNodes)
-            //     if (pair.Key.NodeId == id && pair.Value.NodeId == childNodeId)
-            //         keysToRemove.Add(pair.Key);
-
-            // foreach (var key in keysToRemove)
-            //     linkedChildNodes.Remove(key);
-            // if (keysToRemove.Count > 0)
-            // Debug.Log("Removed " + keysToRemove.Count + " child connections with ID " + id);
-        }
-
-        /* ------------------------- Set Node Relation Type ------------------------- */
-        void SetNodeRelationTypes(int rootId, int id)
-        {
-            if (polityMembers[rootId] == null)
-            {
-                EditorUtility.DisplayDialog(
-               "Root Polity Member not assigned",
-               $"Please assign a Polity Member at Node {rootId}.",
-               "OK"
-               );
-                return;
-            }
-            if (polityMembers[id] == null) return;
-            // if (linkedRelationType.TryGetValue(id, out RelationType relation))
-            // {
-            //     switch (relation)
-            //     {
-            //         case RelationType.Parent:
-            //             if (!polityMembers[rootId].family.parents.Contains(polityMembers[id]))
-            //                 polityMembers[rootId].family.parents.Add(polityMembers[id]);
-            //             // if (!polityMembers[id].children.Contains(polityMembers[rootId]))
-            //             //     polityMembers[id].children.Add(polityMembers[rootId]);
-            //             break;
-            //         case RelationType.Partner:
-            //             if (rootId != 0)//This is a child to partner, i.e child to parent 
-            //             {
-            //                 if (!polityMembers[rootId].family.parents.Contains(polityMembers[id]))
-            //                     polityMembers[rootId].family.parents.Add(polityMembers[id]);
-            //                 // if (!polityMembers[id].children.Contains(polityMembers[rootId]))
-            //                 //     polityMembers[id].children.Add(polityMembers[rootId]);
-            //             }
-            //             else
-            //             {
-            //                 // if (!polityMembers[rootId].family.partners.Contains(polityMembers[id]))
-            //                 //     polityMembers[rootId].family.partners.Add(polityMembers[id]);
-            //                 // if (!polityMembers[id].partners.Contains(polityMembers[rootId]))
-            //                 //     polityMembers[id].partners.Add(polityMembers[rootId]);
-            //             }
-            //             break;
-            //         case RelationType.Children:
-            //             // if (!polityMembers[rootId].children.Contains(polityMembers[id]))
-            //             //     polityMembers[rootId].children.Add(polityMembers[id]);
-            //             // if (!polityMembers[id].parents.Contains(polityMembers[rootId]))
-            //             //     polityMembers[id].parents.Add(polityMembers[rootId]);
-            //             break;
-            //         default:
-            //             Debug.Log("Unknown relationship.");
-            //             break;
-            //     }
-            // }
-            // else Debug.LogWarning("No relation found for ID: " + id);
-        }
-
-        void SetRootNodeRelationTypes(int id) => SetNodeRelationTypes(0, id);
-        /// <summary>
-        /// Clears relations from the start polity Member to its linked counterpart
-        /// </summary>
-        void ClearChildNodeRelation(int id)
-        {
-            if (polityMembers[id].family.parents.Contains(polityMembers[childNodeId]))
-                polityMembers[id].family.parents.Remove(polityMembers[childNodeId]);
-            // if (polityMembers[childNodeId].children.Contains(polityMembers[id]))
-            //     polityMembers[childNodeId].children.Remove(polityMembers[id]);
-
-        }
-        void ClearLinkedNodeRelations(int rootId, int id)
-        {
-            // if (linkedRelationType.ContainsKey(id))
-            // {
-            //     switch (linkedRelationType[id])
-            //     {
-            //         case RelationType.Partner:
-            //             if (polityMembers[rootId].family.partners.Any(p => p.partner == polityMembers[id]))
-            //                 polityMembers[rootId].family.partners.RemoveAll(p => p.partner == polityMembers[id]);
-            //             if (polityMembers[id].family.partners.Any(p => p.partner == polityMembers[rootId]))
-            //                 polityMembers[id].family.partners.RemoveAll(p => p.partner == polityMembers[rootId]);
-            //             break;
-            //         case RelationType.Parent:
-            //             if (polityMembers[rootId].family.parents.Contains(polityMembers[id]))
-            //                 polityMembers[rootId].family.parents.Remove(polityMembers[id]);
-            //             // if (polityMembers[id].children.Contains(polityMembers[rootId]))
-            //             //     polityMembers[id].children.Remove(polityMembers[rootId]);
-            //             break;
-            //         case RelationType.Children:
-            //             // if (polityMembers[rootId].children.Contains(polityMembers[id]))
-            //             //     polityMembers[rootId].children.Remove(polityMembers[id]);
-            //             if (polityMembers[id].family.parents.Contains(polityMembers[rootId]))
-            //                 polityMembers[id].family.parents.Remove(polityMembers[rootId]);
-            //             break;
-            //     }
-            //     linkedRelationType.Remove(id);
-            // }
-        }
-        void ClearRootNodeRelations(int id) => ClearLinkedNodeRelations(0, id);
-
+        #endregion
+      
         bool CheckForDuplicateNode(int id)
         {
             bool isDuplicate = false;
@@ -607,7 +508,7 @@ namespace KL
             return isDuplicate;
         }
 
-        #region Curve Links
+        #region Curves
         /* -------------------------------------------------------------------------- */
         /*                            Bezier Curve Drawers                            */
         /* -------------------------------------------------------------------------- */
@@ -631,30 +532,20 @@ namespace KL
                 CurveAnchor.Child => new(0.5f, 1f),
                 _ => new(0.5f, 0.5f),
             };
-        void DrawNodeCurve(Node start, Node end, CurveAnchor startAnchor)
-        {
-            CurveAnchor endAnchor = GetOppositeAnchor(startAnchor);
-            Vector2 startPos = GetNodeAnchorVector(startAnchor);
-            Vector2 endPos = GetNodeAnchorVector(endAnchor);
-            Color lineColor = GetAnchorLineColor(startAnchor, 0);
-            DrawNodeCurve(start.Rect, end.Rect, startPos, endPos, lineColor);
-        }
 
         void DrawNodeCurve(Link start, Link end, CurveAnchor startAnchor)
         {
             CurveAnchor endAnchor = GetOppositeAnchor(startAnchor);
             Vector2 startPos = GetNodeAnchorVector(startAnchor);
             Vector2 endPos = GetNodeAnchorVector(endAnchor);
-            Color lineColor = GetAnchorLineColor(startAnchor, end.Index);
+            Color lineColor = GetAnchorLineColor(startAnchor, start.Index);
             DrawNodeCurve(start.Node.Rect, end.Node.Rect, startPos, endPos, lineColor);
         }
 
         Color GetAnchorLineColor(CurveAnchor startAnchor, int endIndex)
         {
             if (endIndex < 0 || endIndex >= polityMembers.Count || polityMembers[endIndex] == null)
-            {
                 return Color.white;
-            }
             return startAnchor switch
             {
                 CurveAnchor.Top => Color.blue,

--- a/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
+++ b/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
@@ -18,8 +18,9 @@ namespace KL
         }
         enum RelationType
         {
-            Parents,
-            Partners,
+            Root,
+            Parent,
+            Partner,
             Children,
         }
         RelationType relationType;
@@ -28,19 +29,23 @@ namespace KL
         /* ----------------------------- NODE RENDERERS ----------------------------- */
         struct Node
         {
+            public Rect Rect;
             public int NodeId;
             public NodeAnchor Point;
-            public Node(int nodeId, NodeAnchor point)
+            public Node(Rect rect, int nodeId, NodeAnchor point)
             {
+                Rect = rect;
                 NodeId = nodeId;
                 Point = point;
             }
         }
         SerializedObject serializedObject;
         GUIStyle parentNode, partnerNode, childNode;
-        List<Rect> nodes = new();
-        List<Rect> parentNodes = new();
-        List<Rect> partnerNodes = new();
+        // List<Rect> nodes = new();
+        Dictionary<Rect, RelationType> nodes = new();
+
+        // List<Rect> parentNodes = new();
+        // List<Rect> partnerNodes = new();
 
         Vector2 nodeSize = new(140, 65);
         /// <summary>
@@ -77,7 +82,7 @@ namespace KL
             Vector2 windowCenter = new(position.width / 2, position.height / 2);
             Rect rootNodeRect = new(windowCenter.x + nodeSize.x,
                                     (windowCenter.y / 2) + nodeSize.y / 2, nodeSize.x, 105);
-            nodes.Add(rootNodeRect);
+            nodes.Add(rootNodeRect, RelationType.Root);
         }
 
         public static void ShowWindow()
@@ -99,11 +104,11 @@ namespace KL
             float topBarWidth = position.width;
             GUILayout.BeginArea(new Rect(0, 0, topBarWidth, topBarHeight), "", GUI.skin.window);
             EditorGUILayout.BeginHorizontal();
-            if (GUILayout.Button("Add Node", GUILayout.ExpandWidth(false)))
-            {
-                if (polityMembers[0] != null) nodes.Add(CreateNode(nodes[0].x, nodes[0].y - 100));
-                else Debug.LogWarning("You must assign a root PolityMember first");
-            }
+            // if (GUILayout.Button("Add Node", GUILayout.ExpandWidth(false)))
+            // {
+            //     if (polityMembers[0] != null) nodes.Add(NewNode(nodes[0].x, nodes[0].y - 100));
+            //     else Debug.LogWarning("You must assign a root PolityMember first");
+            // }
             EditorGUILayout.EndHorizontal();
             GUILayout.EndArea();
             /* ------------------------------- SIDEBAR END ------------------------------ */
@@ -120,53 +125,45 @@ namespace KL
             BeginWindows();
 
             foreach (var pair in linkedNodes)
-                DrawNodeCurve(nodes[pair.Key.NodeId], nodes[pair.Value.NodeId], pair.Key.Point, pair.Value.Point);
+                DrawNodeCurve(nodes.ElementAt(pair.Key.NodeId).Key, nodes.ElementAt(pair.Value.NodeId).Key, pair.Key.Point, pair.Value.Point);
             foreach (var pair in linkedChildNodes)
-                DrawNodeCurve(nodes[pair.Value.NodeId], nodes[pair.Key.NodeId], pair.Value.Point, pair.Key.Point);
-            for (int i = 0; i < nodes.Count; i++)
+                DrawNodeCurve(nodes.ElementAt(pair.Value.NodeId).Key, nodes.ElementAt(pair.Key.NodeId).Key, pair.Value.Point, pair.Key.Point);
+            int index = 0;
+            foreach (var node in nodes)
             {
-                if (i == 0)//Root node
+                Rect nodeRect = node.Key;
+                if (node.Value == RelationType.Root)//Root node
                 {
                     if (polityMembers.Any() && polityMembers[0] != null)
                     {
                         if (polityMembers[0].family.parents.Count < 2)
-                            nodes[i] = new Rect(nodes[0].x, nodes[0].y, nodeSize.x, 110);
-                        else nodes[i] = new Rect(nodes[0].x, nodes[0].y, nodeSize.x, 90);
+                            nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 110);
+                        else nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 90);
                     }
-                    nodes[i] = GUI.Window(i, nodes[i], DrawNode, "Root " + i);
+                    nodeRect = GUI.Window(index, node.Key, DrawNode, "Root " + index);
                 }
                 else
                 {
-                    if (linkedRelationType.ContainsKey(i))
+                    switch (node.Value)
                     {
-                        switch (linkedRelationType[i])
-                        {
-                            case RelationType.Parents:
-                                nodes[i] = GUI.Window(i, nodes[i], DrawNode, "Parent " + i, parentNode);
-                                break;
-                            case RelationType.Partners:
-                                nodes[i] = GUI.Window(i, nodes[i], DrawNode, "Partner " + i, partnerNode);
-                                break;
-                            case RelationType.Children:
-                                if (polityMembers[i] != null)
-                                {
-                                    if (polityMembers[i].family.parents.Count == 1)
-                                        nodes[i] = new Rect(nodes[i].x, nodes[i].y, nodeSize.x, 90);
-                                    else nodes[i] = new Rect(nodes[i].x, nodes[i].y, nodeSize.x, 65);
-                                }
-                                nodes[i] = GUI.Window(i, nodes[i], DrawNode, "Child " + i, childNode);
-                                break;
-                        }
+                        case RelationType.Parent:
+                            nodeRect = GUI.Window(index, node.Key, DrawNode, "Parent " + index, parentNode);
+                            break;
+                        case RelationType.Partner:
+                            nodeRect = GUI.Window(index, node.Key, DrawNode, "Partner " + index, partnerNode);
+                            break;
+                        case RelationType.Children:
+                            if (polityMembers[index] != null)
+                            {
+                                if (polityMembers[index].family.parents.Count == 1)
+                                    nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 90);
+                                else nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 65);
+                            }
+                            nodeRect = GUI.Window(index, node.Key, DrawNode, "Child " + index, childNode);
+                            break;
                     }
-                    else nodes[i] = GUI.Window(i, nodes[i], DrawNode, "Node " + i);
                 }
-            }
-            for (int i = 0; i < parentNodes.Count; i++)
-            {
-                DrawNodeCurve(nodes[0], parentNodes[i], NodeAnchor.Bottom, NodeAnchor.Top);
-                // parentNodes[0] = new Rect(nodes[0].x - nodeSize.x, nodes[0].y - nodeSize.y * 2f, nodeSize.x, nodeSize.y);
-
-                // parentNodes[i] = GUI.Window(i, parentNodes[i], DrawNode, "Parent " + i, parentNode);
+                index++;
             }
             EndWindows();
             GUI.EndGroup();
@@ -199,9 +196,13 @@ namespace KL
                 }
             }
         }
-        Rect CreateNode(float x, float y)
+        // Rect NewNode(float x, float y)
+        // {
+        //     return new Rect(x, y, nodeSize.x, nodeSize.y);
+        // }
+        void NewNode(float x, float y, RelationType type)
         {
-            return new Rect(x, y, nodeSize.x, nodeSize.y);
+            nodes.Add(new Rect(x, y, nodeSize.x, nodeSize.y), type);
         }
         Rect MoveNode(Rect node, float x, float y)
         {
@@ -209,21 +210,31 @@ namespace KL
         }
         void AddParentNode()
         {
+            List<Rect> parentNodes = new();
+            foreach (var node in nodes)
+            {
+                if (node.Value == RelationType.Parent)
+                    parentNodes.Add(node.Key);
+            }
+
             if (polityMembers[0].family.parents.Count < 2 &&
                 parentNodes.Count < 2)
             {
-                relationType = RelationType.Parents;
+                relationType = RelationType.Parent;
                 switch (parentNodes.Count)
                 {
                     case 0:
-                        parentNodes.Add(CreateNode(nodes[0].x, nodes[0].y - nodeSize.y * 2f));
-                        Debug.LogError("first ParentNode " + parentNodes[0]);
+                        NewNode(nodes.ElementAt(0).Key.x, nodes.ElementAt(0).Key.y - nodeSize.y * 2f, RelationType.Parent);
                         break;
                     case 1:
-                        parentNodes[0] = MoveNode(parentNodes[0], nodes[0].x - nodeSize.x, nodes[0].y - nodeSize.y * 2f);
-                        Debug.LogError("2nd ParentNode " + parentNodes[0]);
-                        parentNodes.Add(CreateNode(nodes[0].x + nodeSize.x * 2,
-                                                nodes[0].y - nodeSize.y * 2f));
+                        Debug.Log("Parent node b4 " + parentNodes[0].position);
+                        Rect movedNode = MoveNode(parentNodes[0], nodes.ElementAt(0).Key.x - nodeSize.x,
+                                                                nodes.ElementAt(0).Key.y - nodeSize.y * 2f);
+                        Debug.Log("Parent node moved to " + parentNodes[0].position);
+                        nodes.Remove(parentNodes[0]);
+                        nodes.Add(movedNode, RelationType.Parent);
+                        NewNode(nodes.ElementAt(0).Key.x + nodeSize.x,
+                                nodes.ElementAt(0).Key.y - nodeSize.y * 2f, RelationType.Parent);
                         break;
                 }
             }
@@ -239,10 +250,10 @@ namespace KL
                 if (polityMembers[0] != null && PrefabUtility.IsPartOfPrefabAsset(polityMembers[0]))
                     if (!CheckForDuplicateNode(id))
                     {
-                        if (GUILayout.Button(RelationType.Parents.ToString()))
+                        if (GUILayout.Button(RelationType.Parent.ToString()))
                             AddParentNode();
-                        if (GUILayout.Button(RelationType.Partners.ToString()))
-                            relationType = RelationType.Partners;
+                        if (GUILayout.Button(RelationType.Partner.ToString()))
+                            relationType = RelationType.Partner;
                         if (GUILayout.Button(RelationType.Children.ToString()))
                             relationType = RelationType.Children;
                         if (!isRootGenerated) DrawRootNode();
@@ -258,7 +269,7 @@ namespace KL
                         EditorGUILayout.BeginHorizontal();
                         if (linkedRelationType.ContainsKey(id))
                         {
-                            if (linkedRelationType[id] == RelationType.Partners)
+                            if (linkedRelationType[id] == RelationType.Partner)
                             {
                                 if (GUILayout.Button("Attach", GUILayout.ExpandWidth(true)))
                                     EstablishNodeConnection(id);
@@ -293,7 +304,7 @@ namespace KL
                                 EstablishNodeConnection(id);
                         }
                         EditorGUILayout.EndHorizontal();
-                        if (polityMembers[id] != null && nodes[id] != null)
+                        if (polityMembers[id] != null && nodes.ElementAt(id).Key != null)
                             if (polityMembers[id].family.parents.Contains(polityMembers[0]) && polityMembers[id].family.parents.Count < 2)
                                 if (GUILayout.Button("Parent")) childNodeId = id;
                     }
@@ -327,7 +338,7 @@ namespace KL
             }
 
 
-            Rect rootNode = nodes[0];
+            Rect rootNode = nodes.ElementAt(0).Key;
             float currentXOffset;
             #region Parents
             /* -------------------------- Building Parent Nodes ------------------------- */
@@ -336,9 +347,8 @@ namespace KL
                 currentXOffset = -nodeSize.x;
                 polityMembers.Add(root.family.parents[i]);
                 if (i != 0) currentXOffset += nodeSize.x * 2f;
-                nodes.Add(CreateNode(rootNode.x + currentXOffset, rootNode.y - nodeSize.y * 2f));
-
-                relationType = RelationType.Parents;
+                NewNode(rootNode.x + currentXOffset, rootNode.y - nodeSize.y * 2f, RelationType.Parent);
+                relationType = RelationType.Parent;
                 AttachCurveToRootNode(i + 1);
             }
             currentXOffset = nodeSize.x * 2f;
@@ -351,8 +361,9 @@ namespace KL
             {
                 polityMembers.Add(root.family.partners[i].partner);
                 if (i != 0) currentXOffset += nodeSize.x * 2f;
-                nodes.Add(CreateNode(rootNode.x + currentXOffset, rootNode.y * 1.05f));
-                relationType = RelationType.Partners;
+                // nodes.Add(NewNode(rootNode.x + currentXOffset, rootNode.y * 1.05f), RelationType.Partners);
+                NewNode(rootNode.x + currentXOffset, rootNode.y * 1.05f, RelationType.Partner);
+                relationType = RelationType.Partner;
                 AttachCurveToRootNode(polityMembers.Count - 1);
                 partnersIds.Add(polityMembers.Count - 1);
             }
@@ -395,40 +406,40 @@ namespace KL
             Node root, target;
             switch (relationType)
             {
-                case RelationType.Parents:
+                case RelationType.Parent:
                 default:
-                    root = new Node(rootId, NodeAnchor.Top);
-                    target = new Node(id, NodeAnchor.Bottom);
+                    // root = new Node(rootId, NodeAnchor.Top);
+                    // target = new Node(id, NodeAnchor.Bottom);
                     break;
-                case RelationType.Partners:
-                    root = new Node(rootId, NodeAnchor.Right);
-                    target = new Node(id, NodeAnchor.Left);
+                case RelationType.Partner:
+                    // root = new Node(rootId, NodeAnchor.Right);
+                    // target = new Node(id, NodeAnchor.Left);
                     break;
                 case RelationType.Children:
-                    root = new Node(rootId, NodeAnchor.Bottom);
-                    target = new Node(id, NodeAnchor.Top);
+                    // root = new Node(rootId, NodeAnchor.Bottom);
+                    // target = new Node(id, NodeAnchor.Top);
                     break;
             }
-            if (linkedNodes.ContainsKey(target))
-                linkedNodes[target] = root;
-            else
-                linkedNodes.Add(target, root);
-            if (linkedRelationType.ContainsKey(id))
-                linkedRelationType[id] = relationType;
-            else
-                linkedRelationType.Add(id, relationType);
+            // if (linkedNodes.ContainsKey(target))
+            //     linkedNodes[target] = root;
+            // else
+            //     linkedNodes.Add(target, root);
+            // if (linkedRelationType.ContainsKey(id))
+            //     linkedRelationType[id] = relationType;
+            // else
+            //     linkedRelationType.Add(id, relationType);
         }
         void AttachCurveToParentNode(int id)
         {
-            Node root = new(childNodeId, NodeAnchor.Top), target = new(id, NodeAnchor.Child);
-            if (linkedRelationType.ContainsKey(id))
-                if (linkedRelationType[id] == RelationType.Partners)
-                {
-                    if (linkedChildNodes.TryGetValue(target, out Node _target) && _target.Equals(target))
-                    { Debug.LogWarning("PolityMember pair already exists."); return; }
-                    else linkedChildNodes.Add(root, target);
-                }
-                else Debug.LogWarning("A child relation can only be made to a Partner.");
+            // Node root = new(childNodeId, NodeAnchor.Top), target = new(id, NodeAnchor.Child);
+            // if (linkedRelationType.ContainsKey(id))
+            //     if (linkedRelationType[id] == RelationType.Partner)
+            //     {
+            //         if (linkedChildNodes.TryGetValue(target, out Node _target) && _target.Equals(target))
+            //         { Debug.LogWarning("PolityMember pair already exists."); return; }
+            //         else linkedChildNodes.Add(root, target);
+            //     }
+            //     else Debug.LogWarning("A child relation can only be made to a Partner.");
         }
 
         /* -------------------------- Node Curve Detachment ------------------------- */
@@ -475,13 +486,13 @@ namespace KL
             {
                 switch (relation)
                 {
-                    case RelationType.Parents:
+                    case RelationType.Parent:
                         if (!polityMembers[rootId].family.parents.Contains(polityMembers[id]))
                             polityMembers[rootId].family.parents.Add(polityMembers[id]);
                         // if (!polityMembers[id].children.Contains(polityMembers[rootId]))
                         //     polityMembers[id].children.Add(polityMembers[rootId]);
                         break;
-                    case RelationType.Partners:
+                    case RelationType.Partner:
                         if (rootId != 0)//This is a child to partner, i.e child to parent 
                         {
                             if (!polityMembers[rootId].family.parents.Contains(polityMembers[id]))
@@ -529,13 +540,13 @@ namespace KL
             {
                 switch (linkedRelationType[id])
                 {
-                    case RelationType.Partners:
+                    case RelationType.Partner:
                         // if (polityMembers[rootId].partners.Contains(polityMembers[id]))
                         //     polityMembers[rootId].partners.Remove(polityMembers[id]);
                         // if (polityMembers[id].partners.Contains(polityMembers[rootId]))
                         //     polityMembers[id].partners.Remove(polityMembers[rootId]);
                         break;
-                    case RelationType.Parents:
+                    case RelationType.Parent:
                         if (polityMembers[rootId].family.parents.Contains(polityMembers[id]))
                             polityMembers[rootId].family.parents.Remove(polityMembers[id]);
                         // if (polityMembers[id].children.Contains(polityMembers[rootId]))

--- a/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
+++ b/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
@@ -324,6 +324,7 @@ namespace KL
                         {
                             DeleteLink(id);
                             bool moveParent = false;
+                            List<Node> partnersToMove = new();
                             foreach (var node in nodes)
                                 switch (node.Relation)
                                 {
@@ -331,7 +332,6 @@ namespace KL
                                         foreach (var pair in links)
                                             if (pair.Key.Node.Equals(node))
                                             {
-                                                Debug.LogError("Removed parent node " + id + " node ID " + nodes.IndexOf(node));
                                                 Debug.Log("Pair matched index " + pair.Key.Index);
                                                 if (pair.Key.Index > id)
                                                 {
@@ -345,20 +345,24 @@ namespace KL
                                         foreach (var pair in links)
                                             if (pair.Key.Node.Equals(node))
                                             {
-                                                Debug.LogError("Removed partner node " + id + " node ID " + nodes.IndexOf(node));
-                                                Debug.Log("Pair matched index " + pair.Key.Index);
                                                 if (pair.Key.Index > id)
                                                 {
-                                                    pair.Key.ChangeIndex(id);
-                                                    // moveParent = true;
+                                                    int pairDecremented = pair.Key.Index - 1;
+                                                    partnersToMove.Add(node);
+                                                    pair.Key.ChangeIndex(pairDecremented);
                                                 }
-                                                Debug.Log("Pair matched index after " + pair.Key.Index);
+                                                Debug.Log("partner matched index after " + pair.Key.Index);
                                             }
                                         break;
                                 }
                             if (moveParent)
                                 MoveNode(nodes[id], nodes[0].Rect.x, nodes[0].Rect.y - nodeSize.y * 2f);
-                            // }
+                            foreach (var partnerNode in partnersToMove)
+                            {
+                                int partnerIndex = nodes.IndexOf(partnerNode);
+                                float newX = partnerNode.Rect.x - nodeSize.x * 1.5f;
+                                MoveNode(partnerNode, newX, nodes[partnerIndex].Rect.y);
+                            }
                         }
                     }
                     EditorGUILayout.EndHorizontal();
@@ -486,7 +490,6 @@ namespace KL
 
             Rect rootRect = nodes[0].Rect;
             float currentXOffset = 0;
-            #region Parents
             /* -------------------------- Building Parent Nodes ------------------------- */
             for (int i = 0; i < root.family.parents.Count; i++)
             {
@@ -497,9 +500,6 @@ namespace KL
                 AddParentNode();
             }
             // currentXOffset = nodeSize.x * 2f;
-            #endregion
-
-            #region Partners
             /* ------------------------- Building Partner Nodes ------------------------- */
             for (int i = 0; i < root.family.partners.Count; i++)
             {
@@ -510,7 +510,6 @@ namespace KL
                 // CreateLink(partnerNode, nodes[0], CurveAnchor.Top);
             }
             currentXOffset = nodeSize.x / 2;
-            #endregion
             /* ------------------------- Building Children Nodes ------------------------ */
             // for (int i = 0; i < root.children.Count; i++)
             // {

--- a/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
+++ b/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
@@ -30,30 +30,47 @@ namespace KL
         struct Node
         {
             public Rect Rect;
-            public int NodeId;
-            public NodeAnchor Point;
-            public Node(Rect rect, int nodeId, NodeAnchor point)
+            // public int NodeId;
+            public NodeAnchor Anchor;
+            public Node(Rect rect, NodeAnchor anchorPoint)
             {
                 Rect = rect;
-                NodeId = nodeId;
-                Point = point;
+                // NodeId = nodeId;
+                Anchor = anchorPoint;
             }
+        }
+        struct Link
+        {
+            public Rect Rect;
+            public RelationType Relation;
+            // public int NodeId;
+            public NodeAnchor Anchor;
+            public Link(Rect rect, RelationType relation, NodeAnchor anchorPoint)
+            {
+                Rect = rect;
+                Relation = relation;
+                // NodeId = nodeId;
+                Anchor = anchorPoint;
+            }
+            // public Curve(Rect rect, int nodeId, NodeAnchor anchorPoint)
+            // {
+            //     Rect = rect;
+            //     NodeId = nodeId;
+            //     Anchor = anchorPoint;
+            // }
         }
         SerializedObject serializedObject;
         GUIStyle parentNode, partnerNode, childNode;
-        // List<Rect> nodes = new();
+        List<Node> nodes2 = new();
         Dictionary<Rect, RelationType> nodes = new();
-
-        // List<Rect> parentNodes = new();
-        // List<Rect> partnerNodes = new();
-
+        Dictionary<Node, Node> links = new();
         Vector2 nodeSize = new(140, 65);
         /// <summary>
         /// This nodeId is referenced only in a node which is a child of the root node
         /// </summary>
         int childNodeId = -1;
         bool isRootGenerated;
-        Dictionary<Node, Node> linkedNodes = new(), linkedChildNodes = new();
+        // Dictionary<Curve, Curve> linkedNodes = new(), linkedChildNodes = new();
         Dictionary<int, RelationType> linkedRelationType = new();
 
         /* ------------------------------ PAN CONTROLS ------------------------------ */
@@ -75,7 +92,7 @@ namespace KL
 
             nodes.Clear();
             polityMembers.Clear();
-            linkedNodes.Clear();
+            // linkedNodes.Clear();
             linkedRelationType.Clear();
 
             // Calculate the center of the groupRect
@@ -124,10 +141,10 @@ namespace KL
             GUI.BeginGroup(groupRect);
             BeginWindows();
 
-            foreach (var pair in linkedNodes)
-                DrawNodeCurve(nodes.ElementAt(pair.Key.NodeId).Key, nodes.ElementAt(pair.Value.NodeId).Key, pair.Key.Point, pair.Value.Point);
-            foreach (var pair in linkedChildNodes)
-                DrawNodeCurve(nodes.ElementAt(pair.Value.NodeId).Key, nodes.ElementAt(pair.Key.NodeId).Key, pair.Value.Point, pair.Key.Point);
+            // foreach (var pair in linkedNodes)
+            //     DrawNodeCurve(nodeRects.ElementAt(pair.Key.NodeId).Key, nodeRects.ElementAt(pair.Value.NodeId).Key, pair.Key.Point, pair.Value.Point);
+            // foreach (var pair in linkedChildNodes)
+            //     DrawNodeCurve(nodeRects.ElementAt(pair.Value.NodeId).Key, nodeRects.ElementAt(pair.Key.NodeId).Key, pair.Value.Point, pair.Key.Point);
             int index = 0;
             foreach (var node in nodes)
             {
@@ -137,7 +154,7 @@ namespace KL
                     if (polityMembers.Any() && polityMembers[0] != null)
                     {
                         if (polityMembers[0].family.parents.Count < 2)
-                            nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 110);
+                            nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 115);
                         else nodeRect = new Rect(node.Key.x, node.Key.y, nodeSize.x, 90);
                     }
                     nodeRect = GUI.Window(index, node.Key, DrawNode, "Root " + index);
@@ -147,6 +164,7 @@ namespace KL
                     switch (node.Value)
                     {
                         case RelationType.Parent:
+                            DrawNodeCurve(nodes.ElementAt(0).Key, node.Key, NodeAnchor.Top, NodeAnchor.Bottom);
                             nodeRect = GUI.Window(index, node.Key, DrawNode, "Parent " + index, parentNode);
                             break;
                         case RelationType.Partner:
@@ -196,10 +214,10 @@ namespace KL
                 }
             }
         }
-        // Rect NewNode(float x, float y)
-        // {
-        //     return new Rect(x, y, nodeSize.x, nodeSize.y);
-        // }
+        void LinkNodes(Rect rect, NodeAnchor nodeAnchor)
+        {
+            // links.Add(nodes.ElementAt(0).Key, new(rect, nodeAnchor));
+        }
         void NewNode(float x, float y, RelationType type)
         {
             nodes.Add(new Rect(x, y, nodeSize.x, nodeSize.y), type);
@@ -403,7 +421,7 @@ namespace KL
         void AttachCurveToNode(int rootId, int id)
         {
             if (linkedRelationType.ContainsKey(id)) return;
-            Node root, target;
+            // Curve root, target;
             switch (relationType)
             {
                 case RelationType.Parent:
@@ -445,28 +463,28 @@ namespace KL
         /* -------------------------- Node Curve Detachment ------------------------- */
         void DeleteCurveToNode(int rootId, int id)
         {
-            List<Node> keysToRemove = new();
-            foreach (var pair in linkedNodes)
-                if (pair.Key.NodeId == id && pair.Value.NodeId == rootId)
-                    keysToRemove.Add(pair.Key);
+            // List<Curve> keysToRemove = new();
+            // foreach (var pair in linkedNodes)
+            //     if (pair.Key.NodeId == id && pair.Value.NodeId == rootId)
+            //         keysToRemove.Add(pair.Key);
 
-            foreach (var key in keysToRemove)
-                linkedNodes.Remove(key);
-            if (keysToRemove.Count > 0)
-                Debug.Log("Removed " + keysToRemove.Count + " connections with ID " + id);
+            // foreach (var key in keysToRemove)
+            //     linkedNodes.Remove(key);
+            // if (keysToRemove.Count > 0)
+            // Debug.Log("Removed " + keysToRemove.Count + " connections with ID " + id);
         }
         void DeleteCurveToRootNode(int id) => DeleteCurveToNode(0, id);
         void DeleteCurveToParentNode(int id)
         {
-            List<Node> keysToRemove = new();
-            foreach (var pair in linkedChildNodes)
-                if (pair.Key.NodeId == id && pair.Value.NodeId == childNodeId)
-                    keysToRemove.Add(pair.Key);
+            // List<Curve> keysToRemove = new();
+            // foreach (var pair in linkedChildNodes)
+            //     if (pair.Key.NodeId == id && pair.Value.NodeId == childNodeId)
+            //         keysToRemove.Add(pair.Key);
 
-            foreach (var key in keysToRemove)
-                linkedChildNodes.Remove(key);
-            if (keysToRemove.Count > 0)
-                Debug.Log("Removed " + keysToRemove.Count + " child connections with ID " + id);
+            // foreach (var key in keysToRemove)
+            //     linkedChildNodes.Remove(key);
+            // if (keysToRemove.Count > 0)
+            // Debug.Log("Removed " + keysToRemove.Count + " child connections with ID " + id);
         }
 
         /* ------------------------- Set Node Relation Type ------------------------- */

--- a/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
+++ b/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
@@ -39,6 +39,9 @@ namespace KL
         SerializedObject serializedObject;
         GUIStyle parentNode, partnerNode, childNode;
         List<Rect> nodes = new();
+        List<Rect> parentNodes = new();
+        List<Rect> partnerNodes = new();
+
         Vector2 nodeSize = new(140, 65);
         /// <summary>
         /// This nodeId is referenced only in a node which is a child of the root node
@@ -98,8 +101,7 @@ namespace KL
             EditorGUILayout.BeginHorizontal();
             if (GUILayout.Button("Add Node", GUILayout.ExpandWidth(false)))
             {
-                if (polityMembers[0] != null)
-                    nodes.Add(new Rect(nodes[0].x, nodes[0].y - 100, nodeSize.x, nodeSize.y));
+                if (polityMembers[0] != null) nodes.Add(CreateNode(nodes[0].x, nodes[0].y - 100));
                 else Debug.LogWarning("You must assign a root PolityMember first");
             }
             EditorGUILayout.EndHorizontal();
@@ -113,7 +115,7 @@ namespace KL
             float mainPanelWidth = position.width;
             float mainPanelHeight = position.height - topBarHeight;
             GUILayout.BeginArea(new Rect(0, topBarHeight, mainPanelWidth, mainPanelHeight), "", GUI.skin.window);
-            Rect groupRect = new Rect(panX, panY, 5000, 5000);
+            Rect groupRect = new(panX, panY, 5000, 5000);
             GUI.BeginGroup(groupRect);
             BeginWindows();
 
@@ -131,7 +133,7 @@ namespace KL
                             nodes[i] = new Rect(nodes[0].x, nodes[0].y, nodeSize.x, 110);
                         else nodes[i] = new Rect(nodes[0].x, nodes[0].y, nodeSize.x, 90);
                     }
-                    nodes[i] = GUI.Window(i, nodes[i], DrawNodeWindow, "Root " + i);
+                    nodes[i] = GUI.Window(i, nodes[i], DrawNode, "Root " + i);
                 }
                 else
                 {
@@ -140,10 +142,10 @@ namespace KL
                         switch (linkedRelationType[i])
                         {
                             case RelationType.Parents:
-                                nodes[i] = GUI.Window(i, nodes[i], DrawNodeWindow, "Parent " + i, parentNode);
+                                nodes[i] = GUI.Window(i, nodes[i], DrawNode, "Parent " + i, parentNode);
                                 break;
                             case RelationType.Partners:
-                                nodes[i] = GUI.Window(i, nodes[i], DrawNodeWindow, "Partner " + i, partnerNode);
+                                nodes[i] = GUI.Window(i, nodes[i], DrawNode, "Partner " + i, partnerNode);
                                 break;
                             case RelationType.Children:
                                 if (polityMembers[i] != null)
@@ -152,12 +154,19 @@ namespace KL
                                         nodes[i] = new Rect(nodes[i].x, nodes[i].y, nodeSize.x, 90);
                                     else nodes[i] = new Rect(nodes[i].x, nodes[i].y, nodeSize.x, 65);
                                 }
-                                nodes[i] = GUI.Window(i, nodes[i], DrawNodeWindow, "Child " + i, childNode);
+                                nodes[i] = GUI.Window(i, nodes[i], DrawNode, "Child " + i, childNode);
                                 break;
                         }
                     }
-                    else nodes[i] = GUI.Window(i, nodes[i], DrawNodeWindow, "Node " + i);
+                    else nodes[i] = GUI.Window(i, nodes[i], DrawNode, "Node " + i);
                 }
+            }
+            for (int i = 0; i < parentNodes.Count; i++)
+            {
+                DrawNodeCurve(nodes[0], parentNodes[i], NodeAnchor.Bottom, NodeAnchor.Top);
+                // parentNodes[0] = new Rect(nodes[0].x - nodeSize.x, nodes[0].y - nodeSize.y * 2f, nodeSize.x, nodeSize.y);
+
+                // parentNodes[i] = GUI.Window(i, parentNodes[i], DrawNode, "Parent " + i, parentNode);
             }
             EndWindows();
             GUI.EndGroup();
@@ -190,7 +199,36 @@ namespace KL
                 }
             }
         }
-        void DrawNodeWindow(int id)
+        Rect CreateNode(float x, float y)
+        {
+            return new Rect(x, y, nodeSize.x, nodeSize.y);
+        }
+        Rect MoveNode(Rect node, float x, float y)
+        {
+            return new Rect(x, y, node.width, node.height);
+        }
+        void AddParentNode()
+        {
+            if (polityMembers[0].family.parents.Count < 2 &&
+                parentNodes.Count < 2)
+            {
+                relationType = RelationType.Parents;
+                switch (parentNodes.Count)
+                {
+                    case 0:
+                        parentNodes.Add(CreateNode(nodes[0].x, nodes[0].y - nodeSize.y * 2f));
+                        Debug.LogError("first ParentNode " + parentNodes[0]);
+                        break;
+                    case 1:
+                        parentNodes[0] = MoveNode(parentNodes[0], nodes[0].x - nodeSize.x, nodes[0].y - nodeSize.y * 2f);
+                        Debug.LogError("2nd ParentNode " + parentNodes[0]);
+                        parentNodes.Add(CreateNode(nodes[0].x + nodeSize.x * 2,
+                                                nodes[0].y - nodeSize.y * 2f));
+                        break;
+                }
+            }
+        }
+        void DrawNode(int id)
         {
             while (polityMembers.Count <= id) polityMembers.Add(null);
             EditorGUI.BeginChangeCheck();
@@ -201,9 +239,8 @@ namespace KL
                 if (polityMembers[0] != null && PrefabUtility.IsPartOfPrefabAsset(polityMembers[0]))
                     if (!CheckForDuplicateNode(id))
                     {
-                        if (polityMembers[0].family.parents.Count < 2)
-                            if (GUILayout.Button(RelationType.Parents.ToString()))
-                                relationType = RelationType.Parents;
+                        if (GUILayout.Button(RelationType.Parents.ToString()))
+                            AddParentNode();
                         if (GUILayout.Button(RelationType.Partners.ToString()))
                             relationType = RelationType.Partners;
                         if (GUILayout.Button(RelationType.Children.ToString()))
@@ -292,39 +329,35 @@ namespace KL
 
             Rect rootNode = nodes[0];
             float currentXOffset;
+            #region Parents
             /* -------------------------- Building Parent Nodes ------------------------- */
             for (int i = 0; i < root.family.parents.Count; i++)
             {
                 currentXOffset = -nodeSize.x;
                 polityMembers.Add(root.family.parents[i]);
-                if (i == 0)
-                    nodes.Add(new Rect(rootNode.x + currentXOffset, rootNode.y - nodeSize.y * 2f, nodeSize.x, nodeSize.y));
-                else
-                {
-                    currentXOffset += nodeSize.x * 2f;
-                    nodes.Add(new Rect(rootNode.x + currentXOffset, rootNode.y - nodeSize.y * 2f, nodeSize.x, nodeSize.y));
-                }
+                if (i != 0) currentXOffset += nodeSize.x * 2f;
+                nodes.Add(CreateNode(rootNode.x + currentXOffset, rootNode.y - nodeSize.y * 2f));
+
                 relationType = RelationType.Parents;
                 AttachCurveToRootNode(i + 1);
             }
             currentXOffset = nodeSize.x * 2f;
+            #endregion
+
+            #region Partners
             /* ------------------------- Building Partner Nodes ------------------------- */
             List<int> partnersIds = new();
             for (int i = 0; i < root.family.partners.Count; i++)
             {
                 polityMembers.Add(root.family.partners[i].partner);
-                if (i == 0)
-                    nodes.Add(new Rect(rootNode.x + currentXOffset, rootNode.y * 1.05f, nodeSize.x, nodeSize.y));
-                else
-                {
-                    currentXOffset += nodeSize.x * 2f;
-                    nodes.Add(new Rect(rootNode.x + currentXOffset, rootNode.y * 1.05f, nodeSize.x, nodeSize.y));
-                }
+                if (i != 0) currentXOffset += nodeSize.x * 2f;
+                nodes.Add(CreateNode(rootNode.x + currentXOffset, rootNode.y * 1.05f));
                 relationType = RelationType.Partners;
                 AttachCurveToRootNode(polityMembers.Count - 1);
                 partnersIds.Add(polityMembers.Count - 1);
             }
             currentXOffset = nodeSize.x / 2;
+            #endregion
             /* ------------------------- Building Children Nodes ------------------------ */
             // for (int i = 0; i < root.children.Count; i++)
             // {

--- a/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
+++ b/Assets/Polity Manager/Editor/PolityFamilyGraph.cs
@@ -55,7 +55,7 @@ namespace KL
         GUIStyle parentNode, partnerNode, childNode;
         List<Node> nodes = new();
         Dictionary<Link, Link> links = new();
-        Vector2 nodeSize = new(140, 65);
+        readonly Vector2 nodeSize = new(140, 65);
         /// <summary>
         /// This nodeId is referenced only in a node which is a child of the root node
         /// </summary>
@@ -86,7 +86,7 @@ namespace KL
             // Calculate the center of the groupRect
             Vector2 windowCenter = new(position.width / 2, position.height / 2);
             Rect rootNodeRect = new(windowCenter.x + nodeSize.x,
-                                    (windowCenter.y / 2) + nodeSize.y / 2, nodeSize.x, 105);
+                                    (windowCenter.y / 2) + nodeSize.y / 2, nodeSize.x, 110);
             // nodes.Add(rootNodeRect, RelationType.Root);
             nodes.Add(new Node(rootNodeRect, RelationType.Root));
         }
@@ -136,37 +136,21 @@ namespace KL
             foreach (var node in nodes)
             {
                 Rect nodeRect = node.Rect;
-                if (node.Relation == RelationType.Root)//Root node
+                switch (node.Relation)
                 {
-                    if (polityMembers.Any() && polityMembers[0] != null)
-                    {
-                        if (polityMembers[0].family.parents.Count < 2)
-                            nodeRect = new Rect(node.Rect.x, node.Rect.y, nodeSize.x, 115);
-                        else nodeRect = new Rect(node.Rect.x, node.Rect.y, nodeSize.x, 90);
-                    }
-                    nodeRect = GUI.Window(index, node.Rect, DrawNode, "Root " + index);
-                }
-                else
-                {
-                    switch (node.Relation)
-                    {
-                        case RelationType.Parent:
-                            // DrawNodeCurve(nodes2[0].Rect, node.Rect, NodeAnchor.Top, NodeAnchor.Bottom);
-                            nodeRect = GUI.Window(index, node.Rect, DrawNode, "Parent " + index, parentNode);
-                            break;
-                        case RelationType.Partner:
-                            nodeRect = GUI.Window(index, node.Rect, DrawNode, "Partner " + index, partnerNode);
-                            break;
-                        case RelationType.Children:
-                            if (polityMembers[index] != null)
-                            {
-                                if (polityMembers[index].family.parents.Count == 1)
-                                    nodeRect = new Rect(node.Rect.x, node.Rect.y, nodeSize.x, 90);
-                                else nodeRect = new Rect(node.Rect.x, node.Rect.y, nodeSize.x, 65);
-                            }
-                            nodeRect = GUI.Window(index, node.Rect, DrawNode, "Child " + index, childNode);
-                            break;
-                    }
+                    case RelationType.Root:
+                    default:
+                        nodeRect = GUI.Window(index, nodeRect, DrawNode, "Root");
+                        break;
+                    case RelationType.Parent:
+                        nodeRect = GUI.Window(index, nodeRect, DrawNode, "Parent " + index, parentNode);
+                        break;
+                    case RelationType.Partner:
+                        nodeRect = GUI.Window(index, nodeRect, DrawNode, "Partner " + index, partnerNode);
+                        break;
+                    case RelationType.Children:
+                        nodeRect = GUI.Window(index, nodeRect, DrawNode, "Child " + index, childNode);
+                        break;
                 }
                 index++;
             }
@@ -231,32 +215,65 @@ namespace KL
             polityMembers.RemoveAt(nodes.IndexOf(node));
             nodes.Remove(node);
         }
+        #region Parent
+        int GetParentNodeCount()
+        {
+            int count = 0;
+            foreach (var node in nodes)
+                if (node.Relation == RelationType.Parent)
+                    count++;
+            return count;
+        }
         void AddParentNode()
         {
-            List<Node> parentNodes = new();
-            foreach (var node in nodes)
-            {
-                if (node.Relation == RelationType.Parent)
-                    parentNodes.Add(node);
-            }
+            int parentCount = GetParentNodeCount();
             if (polityMembers[0].family.parents.Count < 2 &&
-                parentNodes.Count < 2)
+                parentCount < 2)
             {
-                switch (parentNodes.Count)
+                switch (parentCount)
                 {
                     case 0:
                         Node node = NewNode(nodes[0].Rect.x, nodes[0].Rect.y - nodeSize.y * 2f, RelationType.Parent);
                         CreateLink(node, nodes[0], CurveAnchor.Bottom);
                         break;
                     case 1:
-                        MoveNode(parentNodes[0], nodes[0].Rect.x - nodeSize.x, nodes[0].Rect.y - nodeSize.y * 2f);
-                        Node node1 = NewNode(nodes[0].Rect.x + nodeSize.x,
+                        Node node1 = NewNode(nodes[0].Rect.x + nodeSize.x * 1.5f,
                                  nodes[0].Rect.y - nodeSize.y * 2f, RelationType.Parent);
                         CreateLink(node1, nodes[0], CurveAnchor.Bottom);
                         break;
                 }
             }
         }
+        #endregion
+        //         float xPos = nodes[0].Rect.x + nodeSize.x * (2 + partnerNodes.Count);
+        // float yPos = nodes[0].Rect.position.y;
+        #region Partner
+        void AddPartnerNode()
+        {
+            List<Node> partnerNodes = new();
+            foreach (var node in nodes)
+                if (node.Relation == RelationType.Partner)
+                    partnerNodes.Add(node);
+            float xPos = nodes[0].Rect.x + nodeSize.x * (1.5f + partnerNodes.Count * 1.5f);
+            float yPos = nodes[0].Rect.y + 45 / 2;
+            Node partnerNode = NewNode(xPos, yPos, RelationType.Partner);
+            CreateLink(partnerNode, nodes[0], CurveAnchor.Left);
+        }
+        #endregion
+
+        #region Children
+        void AddChildrenNode()
+        {
+            List<Node> childNodes = new();
+            foreach (var node in nodes)
+                if (node.Relation == RelationType.Children)
+                    childNodes.Add(node);
+            float xPos = nodes[0].Rect.x;
+            float yPos = nodes[0].Rect.y + nodeSize.y * (2f + childNodes.Count * 2f);
+            Node childNode = NewNode(xPos, yPos, RelationType.Children);
+            CreateLink(childNode, nodes[0], CurveAnchor.Top);
+        }
+        #endregion
         void DrawNode(int id)
         {
             while (polityMembers.Count <= id) polityMembers.Add(null);
@@ -273,23 +290,36 @@ namespace KL
                 if (polityMembers[0] != null && PrefabUtility.IsPartOfPrefabAsset(polityMembers[0]))
                     if (!CheckForDuplicateNode(id))
                     {
-                        if (GUILayout.Button(RelationType.Parent.ToString()))
-                            AddParentNode();
+                        List<Node> parentNodes = new();
+                        foreach (var node in nodes)
+                            if (node.Relation == RelationType.Parent)
+                                parentNodes.Add(node);
+                        Debug.LogError("partnerNodes count " + parentNodes.Count);
+                        if (parentNodes.Count < 2)
+                        {
+                            if (GUILayout.Button(RelationType.Parent.ToString()))
+                                AddParentNode();
+                        }
                         if (GUILayout.Button(RelationType.Partner.ToString()))
-                            relationType = RelationType.Partner;
+                            AddPartnerNode();
                         if (GUILayout.Button(RelationType.Children.ToString()))
-                            relationType = RelationType.Children;
+                            AddChildrenNode();
                         if (!isRootGenerated) InitializeNodes();
                     }
             }
             else
             {
-                if (polityMembers[id] != null && PrefabUtility.IsPartOfPrefabAsset(polityMembers[id]))
+                // if (polityMembers[id] != null && PrefabUtility.IsPartOfPrefabAsset(polityMembers[id]))
                 {
-                    if (!CheckForDuplicateNode(id))
+                    // if (!CheckForDuplicateNode(id))
                     {
                         EditorGUILayout.BeginHorizontal();
                         {
+                            if (nodes[id].Relation == RelationType.Partner)
+                            {
+                                if (GUILayout.Button("Add Child", GUILayout.ExpandWidth(true)))
+                                    relationType = RelationType.Children;
+                            }
                             if (GUILayout.Button("Remove", GUILayout.ExpandWidth(true)))
                                 DeleteLink(id);
                         }
@@ -356,28 +386,30 @@ namespace KL
                 {
                     case RelationType.Parent:
                         bool partnerFound = false;
-                        for (int i = 0; i < member.family.partners.Count; i++)
-                        {
-                            if (member.family.partners[i].partner == valueMember)
-                            {
-                                if (!member.family.partners[i].children.Contains(valueMember))
-                                    member.family.partners[i].children.Add(valueMember);
-                                partnerFound = true;
-                                break;
-                            }
-                        }
+                        // for (int i = 0; i < member.family.partners.Count; i++)
+                        // {
+                        //     if (member.family.partners[i].partner == valueMember)
+                        //     {
+                        //         if (!member.family.partners[i].children.Contains(valueMember))
+                        //             member.family.partners[i].children.Add(valueMember);
+                        //         partnerFound = true;
+                        //         break;
+                        //     }
+                        // }
 
-                        if (!partnerFound)
-                        {
-                            PolityFamily.FamilyStruct.PartnerStruct newPartner = new()
-                            {
-                                children = new List<PolityMember> { valueMember }
-                            };
-                            member.family.partners.Add(newPartner);
-                        }
+                        // if (!partnerFound)
+                        // {
+                        //     PolityFamily.FamilyStruct.PartnerStruct newPartner = new()
+                        //     {
+                        //         children = new List<PolityMember> { valueMember }
+                        //     };
+                        //     member.family.partners.Add(newPartner);
+                        // }
 
                         if (!valueMember.family.parents.Contains(member))
                             valueMember.family.parents.Add(member);
+                        if (!member.family.children.Contains(valueMember))
+                            member.family.children.Add(valueMember);
                         break;
                 }
             }
@@ -436,15 +468,15 @@ namespace KL
 
 
             Rect rootRect = nodes[0].Rect;
-            float currentXOffset;
+            float currentXOffset = 0;
             #region Parents
             /* -------------------------- Building Parent Nodes ------------------------- */
             for (int i = 0; i < root.family.parents.Count; i++)
             {
-                currentXOffset = 0;
-                if (i != 0) currentXOffset += nodeSize.x * 2f;
-                Node parentNode = NewNode(rootRect.x + currentXOffset, rootRect.y - nodeSize.y * 2f, RelationType.Parent);
-                CreateLink(parentNode, nodes[0], CurveAnchor.Bottom);
+                // if (i != 0) currentXOffset += nodeSize.x * 2f;
+                // Node parentNode = NewNode(rootRect.x + currentXOffset, rootRect.y - nodeSize.y * 2f, RelationType.Parent);
+                // CreateLink(parentNode, nodes[0], CurveAnchor.Bottom);
+                AddParentNode();
                 polityMembers.Add(root.family.parents[i]);
             }
             // currentXOffset = nodeSize.x * 2f;
@@ -452,13 +484,13 @@ namespace KL
 
             #region Partners
             /* ------------------------- Building Partner Nodes ------------------------- */
-            List<int> partnersIds = new();
             for (int i = 0; i < root.family.partners.Count; i++)
             {
-                currentXOffset = -nodeSize.x;
-                if (i != 0) currentXOffset += nodeSize.x * 2f;
-                Node partnerNode = NewNode(rootRect.x + currentXOffset, +nodeSize.y * 2f, RelationType.Partner);
-                CreateLink(partnerNode, nodes[0], CurveAnchor.Top);
+                // currentXOffset = -nodeSize.x;
+                // if (i != 0) currentXOffset += nodeSize.x * 2f;
+                // Node partnerNode = NewNode(rootRect.x + currentXOffset, +nodeSize.y * 2f, RelationType.Partner);
+                AddPartnerNode();
+                // CreateLink(partnerNode, nodes[0], CurveAnchor.Top);
             }
             currentXOffset = nodeSize.x / 2;
             #endregion
@@ -488,7 +520,7 @@ namespace KL
         }
 
         #endregion
-      
+
         bool CheckForDuplicateNode(int id)
         {
             bool isDuplicate = false;
@@ -562,9 +594,9 @@ namespace KL
             Vector3 endPos = new(end.x + end.width * endVector.x, end.y + end.height * endVector.y, 0);
             Vector3 startTan = startPos + Vector3.right * (-50 + 100 * startVector.x) + Vector3.up * (-50 + 100 * startVector.y);
             Vector3 endTan = endPos + Vector3.right * (-50 + 100 * endVector.x) + Vector3.up * (-50 + 100 * endVector.y);
-            Color shadowCol = new(200, 200, 200, .25f);
-            for (int i = 0; i < 3; i++) // Draw a shadow
-                Handles.DrawBezier(startPos, endPos, startTan, endTan, shadowCol, null, (i + 1) * 5);
+            // Color shadowCol = new(200, 200, 200, .25f);
+            // for (int i = 0; i < 3; i++) // Draw a shadow
+            //     Handles.DrawBezier(startPos, endPos, startTan, endTan, shadowCol, null, (i + 1) * 5);
             Handles.DrawBezier(startPos, endPos, startTan, endTan, lineColor, null, 2);
         }
     }

--- a/Assets/Polity Manager/PolityFamily.cs
+++ b/Assets/Polity Manager/PolityFamily.cs
@@ -22,7 +22,7 @@ namespace KL
             public struct PartnerStruct
             {
                 public PolityMember partner;
-                public PolityMember[] children;
+                public List<PolityMember> children;
             }
         }
 

--- a/Assets/Polity Manager/PolityFamily.cs
+++ b/Assets/Polity Manager/PolityFamily.cs
@@ -17,7 +17,10 @@ namespace KL
         public struct FamilyStruct
         {
             public List<PolityMember> parents;
-            public List<PartnerStruct> partners;
+            // public List<PartnerStruct> partners;
+            public List<PolityMember> partners;
+            public List<PolityMember> children;
+
             [Serializable]
             public struct PartnerStruct
             {


### PR DESCRIPTION
This pull requests reworks the PolityFamilyGraph (renamed from PolityMemberGraph), changing the way nodes are created and removed, which only needs to be done from the root node and automatically positions itself relative to that root node rather than dragged around by the user. 